### PR TITLE
SessionLearning: periodic atomic persistence and outcome tracking

### DIFF
--- a/src/main/java/dev/nozh/client/NozhModClient.java
+++ b/src/main/java/dev/nozh/client/NozhModClient.java
@@ -19,6 +19,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 
 /**
  * NOZH Client-side initializer - FULL INTEGRATION.
@@ -33,10 +34,12 @@ public class NozhModClient implements ClientModInitializer {
     private static GovernorRunner governorRunner;
     private static ActionBus actionBus;
     private static StateStore stateStore;
+    private static dev.nozh.core.intelligence.SessionLearning sessionLearning;
 
     private static int tickCounter = 0;
     private static final int TELEMETRY_UPDATE_INTERVAL = 20; // Every second (20 ticks)
     private static final int GOVERNOR_POLL_INTERVAL = 100; // Every 5 seconds (100 ticks)
+    private static final int SESSION_SAVE_INTERVAL = 1200; // Every 60 seconds (1200 ticks)
 
     @Override
     public void onInitializeClient() {
@@ -77,11 +80,16 @@ public class NozhModClient implements ClientModInitializer {
         StandardCapabilityExecutor capabilityExecutor = new StandardCapabilityExecutor(providerRegistry, logger);
 
         // 8. Create ActionProcessor bridge
-        StandardActionProcessor actionProcessor = new StandardActionProcessor(capabilityExecutor, logger);
-
         // Create SessionLearning
-        dev.nozh.core.intelligence.SessionLearning sessionLearning = new dev.nozh.core.intelligence.SessionLearning(
+        sessionLearning = new dev.nozh.core.intelligence.SessionLearning(
                 net.fabricmc.loader.api.FabricLoader.getInstance().getConfigDir().toFile());
+
+        // 8. Create ActionProcessor bridge
+        StandardActionProcessor actionProcessor = new StandardActionProcessor(
+                capabilityExecutor,
+                logger,
+                sessionLearning,
+                () -> perfManager != null ? perfManager.getSnapshot() : dev.nozh.api.PerfSnapshot.empty());
 
         // Create ScenarioDetector (Fabric implementation)
         dev.nozh.core.context.ScenarioDetector scenarioDetector = new dev.nozh.fabric.context.FabricScenarioDetector();
@@ -132,6 +140,16 @@ public class NozhModClient implements ClientModInitializer {
             if (tickCounter % GOVERNOR_POLL_INTERVAL == 0) {
                 governorRunner.onTick();
             }
+
+            if (tickCounter % SESSION_SAVE_INTERVAL == 0) {
+                sessionLearning.saveIfDue();
+            }
+        });
+
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {
+            if (sessionLearning != null) {
+                sessionLearning.save();
+            }
         });
 
         // === COMMANDS & SHUTDOWN ===
@@ -143,6 +161,9 @@ public class NozhModClient implements ClientModInitializer {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             dev.nozh.core.util.DebugLogger.log("SHUTDOWN", "NOZH shutting down...");
             dev.nozh.core.util.DebugLogger.close();
+            if (sessionLearning != null) {
+                sessionLearning.save();
+            }
         }, "NOZH-Shutdown"));
 
         dev.nozh.core.util.DebugLogger.log("INIT", "NOZH Client initialized successfully");

--- a/src/main/java/dev/nozh/core/bus/StandardActionProcessor.java
+++ b/src/main/java/dev/nozh/core/bus/StandardActionProcessor.java
@@ -1,9 +1,14 @@
 package dev.nozh.core.bus;
 
+import dev.nozh.api.PerfSnapshot;
 import dev.nozh.core.NozhLogger;
+import dev.nozh.core.config.ConfigManager;
+import dev.nozh.core.config.NozhConfig;
+import dev.nozh.core.intelligence.SessionLearning;
 
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Standard implementation of ActionProcessor (Contract 2, Paso 2.4).
@@ -30,10 +35,22 @@ public final class StandardActionProcessor implements ActionProcessor {
 
     private final CapabilityExecutor executor;
     private final NozhLogger logger;
+    private final SessionLearning sessionLearning;
+    private final Supplier<PerfSnapshot> perfSnapshotSupplier;
 
     public StandardActionProcessor(CapabilityExecutor executor, NozhLogger logger) {
+        this(executor, logger, null, PerfSnapshot::empty);
+    }
+
+    public StandardActionProcessor(
+            CapabilityExecutor executor,
+            NozhLogger logger,
+            SessionLearning sessionLearning,
+            Supplier<PerfSnapshot> perfSnapshotSupplier) {
         this.executor = executor;
         this.logger = logger;
+        this.sessionLearning = sessionLearning;
+        this.perfSnapshotSupplier = perfSnapshotSupplier != null ? perfSnapshotSupplier : PerfSnapshot::empty;
     }
 
     @Override
@@ -69,6 +86,7 @@ public final class StandardActionProcessor implements ActionProcessor {
     private void processApply(Command.ApplyCapability cmd, long startedAt, Consumer<CommandExecutionReport> callback) {
         CapabilityId capability = cmd.capability();
         CapabilityValue value = cmd.value();
+        PerfSnapshot beforeSnapshot = perfSnapshotSupplier.get();
 
         // Store old value for potential rollback
         Optional<CapabilityValue> oldValue = Optional.empty();
@@ -147,6 +165,7 @@ public final class StandardActionProcessor implements ActionProcessor {
                 error,
                 rollbackReason);
 
+        recordLearningOutcome(capability, finalState, beforeSnapshot, perfSnapshotSupplier.get());
         callback.accept(report);
     }
 
@@ -197,6 +216,40 @@ public final class StandardActionProcessor implements ActionProcessor {
                 Optional.of("Benchmark not implemented yet (Phase 7)"),
                 Optional.empty());
         callback.accept(report);
+    }
+
+    private void recordLearningOutcome(
+            CapabilityId capability,
+            CommandLifecycle finalState,
+            PerfSnapshot beforeSnapshot,
+            PerfSnapshot afterSnapshot) {
+        if (sessionLearning == null || capability == null) {
+            return;
+        }
+
+        if (finalState != CommandLifecycle.SUCCESS) {
+            sessionLearning.recordFailure(capability);
+            return;
+        }
+
+        if (beforeSnapshot == null || afterSnapshot == null
+                || !beforeSnapshot.sufficientData() || !afterSnapshot.sufficientData()) {
+            sessionLearning.recordSuccess(capability, 0.0);
+            return;
+        }
+
+        double avgDelta = beforeSnapshot.avgFrametimeMs() - afterSnapshot.avgFrametimeMs();
+        double p95Delta = beforeSnapshot.p95FrametimeMs() - afterSnapshot.p95FrametimeMs();
+
+        NozhConfig config = ConfigManager.getConfig();
+        boolean improved = avgDelta >= config.improvementEpsilonAvgMs
+                || p95Delta >= config.improvementEpsilonP95Ms;
+
+        if (improved) {
+            sessionLearning.recordSuccess(capability, Math.max(0.0, avgDelta));
+        } else {
+            sessionLearning.recordFailure(capability);
+        }
     }
 
     /**

--- a/src/main/java/dev/nozh/core/intelligence/SessionLearning.java
+++ b/src/main/java/dev/nozh/core/intelligence/SessionLearning.java
@@ -7,7 +7,12 @@ import com.google.gson.GsonBuilder;
 
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,13 +29,22 @@ import java.util.Map;
 public final class SessionLearning {
 
     private static final String STATS_FILE = "session_stats.json";
+    private static final String STATS_TMP_FILE = "session_stats.json.tmp";
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final long SAVE_INTERVAL_MILLIS = 60000;
 
     private final Map<String, ActionStats> history = new HashMap<>();
     private final File statsFile;
+    private final Path statsPath;
+    private final Path tmpPath;
+    private int lastSavedHash = 0;
+    private long lastSaveMillis = 0;
+    private boolean dirty = false;
 
     public SessionLearning(File configDir) {
         this.statsFile = new File(configDir, STATS_FILE);
+        this.statsPath = statsFile.toPath();
+        this.tmpPath = new File(configDir, STATS_TMP_FILE).toPath();
         load();
     }
 
@@ -47,6 +61,7 @@ public final class SessionLearning {
         stats.lastSuccessTime = System.currentTimeMillis();
         stats.totalFpsGain += fpsGainMs;
         stats.avgFpsGain = stats.totalFpsGain / stats.successCount;
+        dirty = true;
     }
 
     /**
@@ -60,6 +75,7 @@ public final class SessionLearning {
         stats.totalAttempts++;
         stats.failureCount++;
         stats.lastFailureTime = System.currentTimeMillis();
+        dirty = true;
     }
 
     /**
@@ -124,21 +140,71 @@ public final class SessionLearning {
      * Called on shutdown or periodically.
      */
     public void save() {
+        saveInternal(true);
+    }
+
+    /**
+     * Save stats to disk if the interval has elapsed.
+     */
+    public void saveIfDue() {
+        saveInternal(false);
+    }
+
+    private void saveInternal(boolean force) {
         try {
-            // Ensure parent directory exists
+            long now = System.currentTimeMillis();
+            if (!force) {
+                if (!dirty || now - lastSaveMillis < SAVE_INTERVAL_MILLIS) {
+                    return;
+                }
+            }
+
             File parent = statsFile.getParentFile();
             if (parent != null && !parent.exists()) {
                 parent.mkdirs();
             }
 
-            // Write JSON
-            try (FileWriter writer = new FileWriter(statsFile)) {
-                GSON.toJson(history, writer);
+            String json = GSON.toJson(history);
+            int currentHash = json.hashCode();
+            if (!force && currentHash == lastSavedHash) {
+                dirty = false;
+                lastSaveMillis = now;
+                return;
             }
 
+            Files.writeString(
+                    tmpPath,
+                    json,
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE);
+
+            Files.move(
+                    tmpPath,
+                    statsPath,
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE);
+
+            lastSavedHash = currentHash;
+            lastSaveMillis = now;
+            dirty = false;
+
             NozhConstants.LOGGER.info("Session learning stats saved ({} entries)", history.size());
-        } catch (Exception e) {
+        } catch (IOException e) {
             NozhConstants.LOGGER.warn("Failed to save session stats: {}", e.getMessage());
+
+            try {
+                Files.deleteIfExists(tmpPath);
+            } catch (IOException cleanup) {
+            }
+
+            try {
+                String json = GSON.toJson(history);
+                Files.writeString(statsPath, json, StandardCharsets.UTF_8,
+                        StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+            } catch (IOException ignored) {
+            }
         }
     }
 
@@ -159,6 +225,8 @@ public final class SessionLearning {
 
             if (loaded != null) {
                 history.putAll(loaded);
+                lastSavedHash = GSON.toJson(history).hashCode();
+                lastSaveMillis = System.currentTimeMillis();
                 NozhConstants.LOGGER.info("Session learning loaded ({} entries)", history.size());
             }
         } catch (Exception e) {


### PR DESCRIPTION
### Motivation
- Persist session learning more frequently (not only on shutdown) so runtime improvements/failures are not lost.
- Record real action outcomes (success/failure) using measured performance deltas to improve recommendations.
- Use atomic writes for session stats to avoid corruption, mirroring `StateManager` guarantees.
- Hook saves into the client lifecycle to ensure durability on disconnect and shutdown.

### Description
- Added dirty tracking, `saveIfDue()` and atomic save logic (tmp file + `ATOMIC_MOVE`) with hash checks and an interval in `dev.nozh.core.intelligence.SessionLearning` and introduced `STATS_TMP_FILE` and `SAVE_INTERVAL_MILLIS`.
- Extended `dev.nozh.core.bus.StandardActionProcessor` to accept a `SessionLearning` and a `PerfSnapshot` supplier and to call `recordSuccess`/`recordFailure` based on `avg`/`p95` frametime deltas using config epsilons.
- Wired `SessionLearning` into `dev.nozh.client.NozhModClient`, added periodic tick-based calls to `sessionLearning.saveIfDue()`, and registered disconnect and shutdown hooks to call `sessionLearning.save()`.
- Stats are persisted to `config/nozh/session_stats.json` atomically and skip writes when unchanged to reduce I/O (hash + dirty flag), consistent with `StateManager` behavior.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580b1cf58c832d943602e9ce8fc8d0)