### PR TITLE
Sync RuntimeState with NozhConfig and push config changes to StateStore

### DIFF
--- a/src/main/java/dev/nozh/client/NozhCommands.java
+++ b/src/main/java/dev/nozh/client/NozhCommands.java
@@ -7,6 +7,7 @@ import dev.nozh.core.config.NozhConfig;
 import dev.nozh.core.safety.CrashLoopGuard;
 import dev.nozh.core.safety.StateManager;
 import dev.nozh.core.safety.NozhState;
+import dev.nozh.core.state.StateStore;
 import dev.nozh.core.util.NozhText;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -250,6 +251,7 @@ public final class NozhCommands {
         config.enabled = true;
         config.allowAutoTuning = true;
         ConfigManager.save();
+        StateStore.getInstance().update(state -> state.withConfig(config));
 
         source.sendFeedback(Text.translatable("nozh.enable.success"));
     }
@@ -258,6 +260,7 @@ public final class NozhCommands {
         NozhConfig config = ConfigManager.getConfig();
         config.enabled = false;
         ConfigManager.save();
+        StateStore.getInstance().update(state -> state.withConfig(config));
 
         source.sendFeedback(Text.translatable("nozh.disable.success"));
     }

--- a/src/main/java/dev/nozh/client/NozhModMenuIntegration.java
+++ b/src/main/java/dev/nozh/client/NozhModMenuIntegration.java
@@ -6,6 +6,7 @@ import dev.nozh.NozhConstants;
 import dev.nozh.core.config.ConfigManager;
 import dev.nozh.core.config.NozhConfig;
 import dev.nozh.core.safety.CrashLoopGuard;
+import dev.nozh.core.state.StateStore;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.DrawContext;
@@ -101,6 +102,7 @@ public class NozhModMenuIntegration implements ModMenuApi {
                     button -> {
                         config.enabled = !config.enabled;
                         ConfigManager.save();
+                        StateStore.getInstance().update(state -> state.withConfig(config));
                         this.clearAndInit();
                     });
             addDrawableChild(enabledButton);
@@ -115,6 +117,7 @@ public class NozhModMenuIntegration implements ModMenuApi {
                     button -> {
                         config.debugLogs = !config.debugLogs;
                         ConfigManager.save();
+                        StateStore.getInstance().update(state -> state.withConfig(config));
                         this.clearAndInit();
                     });
             addDrawableChild(debugButton);
@@ -129,6 +132,7 @@ public class NozhModMenuIntegration implements ModMenuApi {
                     button -> {
                         config.rollbackEnabled = !config.rollbackEnabled;
                         ConfigManager.save();
+                        StateStore.getInstance().update(state -> state.withConfig(config));
                         this.clearAndInit();
                     });
             addDrawableChild(rollbackButton);
@@ -143,6 +147,7 @@ public class NozhModMenuIntegration implements ModMenuApi {
                     button -> {
                         config.allowAutoTuning = !config.allowAutoTuning;
                         ConfigManager.save();
+                        StateStore.getInstance().update(state -> state.withConfig(config));
                         this.clearAndInit();
                     });
             addDrawableChild(autoTuningButton);
@@ -165,6 +170,7 @@ public class NozhModMenuIntegration implements ModMenuApi {
                         }
                         config.targetFps = fpsOptions[(currentIndex + 1) % fpsOptions.length];
                         ConfigManager.save();
+                        StateStore.getInstance().update(state -> state.withConfig(config));
                         this.clearAndInit();
                     });
             addDrawableChild(targetFpsButton);
@@ -182,6 +188,7 @@ public class NozhModMenuIntegration implements ModMenuApi {
                     Text.translatable("nozh.config.preset.low.tooltip"),
                     button -> {
                         ConfigPresets.applyLowEnd();
+                        StateStore.getInstance().update(state -> state.withConfig(ConfigManager.getConfig()));
                         this.clearAndInit();
                     });
             addDrawableChild(lowButton);
@@ -193,6 +200,7 @@ public class NozhModMenuIntegration implements ModMenuApi {
                     Text.translatable("nozh.config.preset.mid.tooltip"),
                     button -> {
                         ConfigPresets.applyMidRange();
+                        StateStore.getInstance().update(state -> state.withConfig(ConfigManager.getConfig()));
                         this.clearAndInit();
                     });
             addDrawableChild(midButton);
@@ -204,6 +212,7 @@ public class NozhModMenuIntegration implements ModMenuApi {
                     Text.translatable("nozh.config.preset.high.tooltip"),
                     button -> {
                         ConfigPresets.applyHighEnd();
+                        StateStore.getInstance().update(state -> state.withConfig(ConfigManager.getConfig()));
                         this.clearAndInit();
                     });
             addDrawableChild(highButton);
@@ -287,6 +296,7 @@ public class NozhModMenuIntegration implements ModMenuApi {
                     Text.translatable("nozh.config.confirm.yes"),
                     button -> {
                         ConfigManager.resetToDefaults();
+                        StateStore.getInstance().update(state -> state.withConfig(ConfigManager.getConfig()));
                         this.client.setScreen(parent);
                     }).dimensions(centerX - 105, centerY + 20, 100, 20).build());
 

--- a/src/main/java/dev/nozh/core/state/RuntimeState.java
+++ b/src/main/java/dev/nozh/core/state/RuntimeState.java
@@ -150,6 +150,24 @@ public record RuntimeState(
     }
 
     /**
+     * Update config-driven flags (immutable).
+     */
+    public RuntimeState withConfig(dev.nozh.core.config.NozhConfig config) {
+        return new RuntimeState(
+                config.enabled,
+                safeMode,
+                config.allowAutoTuning,
+                config.debugLogs,
+                governorDisabled, governorCooldownActive, governorLastActionTimestamp,
+                benchmarkRunning, benchmarkStartTimestamp,
+                pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
+                sessionChangesCount,
+                avgFrametimeMs, p95FrametimeMs, spikeCount,
+                sessionStartTime, stateVersion,
+                currentScenario);
+    }
+
+    /**
      * Create state from config (initialization).
      */
     public static RuntimeState fromConfig(dev.nozh.core.config.NozhConfig config) {


### PR DESCRIPTION
### Motivation
- Ensure runtime state reflects user configuration changes made via commands or the Mod Menu so behavior is consistent across threads and components.
- Prevent divergence between what is persisted in `ConfigManager` and what the system acts on in `StateStore` after UI/command updates.
- Provide a single immutable mapping from `NozhConfig` to `RuntimeState` to make updates safe and explicit.

### Description
- Add `RuntimeState.withConfig(NozhConfig)` which remaps config-driven flags (`enabled`, `allowAutoTuning`, `debugLogs`) into a new `RuntimeState` instance.
- Update `NozhCommands` to call `StateStore.getInstance().update(state -> state.withConfig(config))` after `ConfigManager.save()` in `runEnable` and `runDisable`.
- Update `NozhModMenuIntegration` to call `StateStore.getInstance().update(state -> state.withConfig(config))` after each config change (toggles, target FPS changes, presets) and after `ConfigManager.resetToDefaults()`.
- Add required imports for `StateStore` in the modified files and keep existing `ConfigManager.save()` behavior.

### Testing
- No automated tests were executed as part of this change.
- The change set is limited to state mapping and call sites and does not modify persistence behavior in `ConfigManager`.
- Manual runtime validation is expected during integration runs (not performed here).
- No test failures reported (no tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580b2a3c48832dbe7da4e3f4597ad4)