### PR TITLE
Add frametime benchmarking methodology guide

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,116 @@
+# Benchmarking Methodology (Frametime)
+
+This document defines **how to measure frametime stability** for NOZH, the **reproducible scenarios** to run, and the **reporting format** (tables + graphs) for P95/P99 results.
+
+## 1) Measurement Methodology
+
+### Tools (choose one primary + one secondary verifier)
+- **Spark** (recommended):
+  - Use the `frametime` / `fps` graph view and export if available.
+  - Capture raw frametime samples or summary percentiles.
+- **VisualVM** (secondary verifier):
+  - Attach to the JVM and ensure frame pacing issues correlate with CPU/GPU load.
+  - Use sampling to correlate frametime spikes with thread activity.
+- **Frametime overlay tools** (e.g., built-in frametime graphs or external overlays):
+  - Record per-frame data if possible; otherwise capture P95/P99 from overlay.
+
+### Measurement Duration
+- **Warm-up:** 60s (discard from results).
+- **Measurement window:** 180s minimum (longer for unstable scenarios).
+- **Cooldown:** 30s (optional, not counted).
+
+### Hardware + Environment Requirements (must be documented)
+- **CPU / GPU / RAM** (exact model + clock if relevant).
+- **OS + JVM + MC version**.
+- **Display / resolution** (e.g., 2560×1440 @ 144Hz).
+- **Renderer / shaders** (and version).
+- **Power mode** (e.g., High Performance, laptop plugged in).
+- **Background load** (close heavy apps; record unavoidable daemons).
+
+### Graphics + Game Config (must be fixed)
+- **Render distance** (e.g., 12–16).
+- **Simulation distance** (e.g., 8–12).
+- **Shadow / shader settings**.
+- **Mipmaps / biome blend**.
+- **Entity distance** and **particles**.
+
+### Data Collected
+- **Average frametime (ms)**
+- **P95 frametime (ms)**
+- **P99 frametime (ms)** (if sample count ≥ 2,000)
+- **Spike count** (>500ms, if available)
+- **Sample count**
+
+## 2) Reproducible Scenarios
+
+Run **all three** scenarios if possible. Each scenario must be a **saved world** with coordinates and a short reproduction script.
+
+### Scenario A — Combat with Mobs
+- **World:** Flat + test arena; fixed time of day.
+- **Setup:** 50–100 mobs in a bounded area.
+- **Repro steps:**
+  1. Teleport to arena (`/tp <coords>`).
+  2. Start combat with a consistent pattern (same weapon, same pathing).
+  3. Measure for 180s.
+
+### Scenario B — Redstone Tick-Heavy
+- **World:** Redstone stress test (clock circuits, observers, pistons).
+- **Setup:** 5–10 large contraptions running simultaneously.
+- **Repro steps:**
+  1. Teleport to control room.
+  2. Enable all clocks with a single lever.
+  3. Measure for 180s while idling at the same location.
+
+### Scenario C — Megabase with Entities
+- **World:** Large base with dense entities (villagers, item frames, hoppers).
+- **Setup:** Minimum 300 active entities within render range.
+- **Repro steps:**
+  1. Teleport to base center.
+  2. Walk a fixed 30s path loop, repeat 6 times.
+  3. Measure for 180s.
+
+## 3) Recording Configuration
+
+For each run, capture:
+- **Mods list** (exact versions)
+- **Shader pack** (and version)
+- **Render distance / simulation distance**
+- **NOZH config** (notably thresholds + target FPS)
+- **Any deviations** from the methodology
+
+## 4) Results Template (Table + Graphs)
+
+> Replace placeholders with actual measurements. If multiple runs are performed, report **mean** and **std dev** per scenario.
+
+### Table (per scenario)
+
+| Scenario | Avg Frametime (ms) | P95 (ms) | P99 (ms) | Spike Count | Samples | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Combat (mobs) | `--` | `--` | `--` | `--` | `--` | `--` |
+| Redstone | `--` | `--` | `--` | `--` | `--` | `--` |
+| Megabase | `--` | `--` | `--` | `--` | `--` | `--` |
+
+### Graphs
+
+**Option A — Mermaid (if supported):**
+
+```mermaid
+xychart-beta
+  title "Frametime P95/P99 by Scenario"
+  x-axis [Combat, Redstone, Megabase]
+  y-axis "Frametime (ms)" 0 --> 80
+  bar "P95" [0, 0, 0]
+  bar "P99" [0, 0, 0]
+```
+
+**Option B — External chart (CSV export):**
+
+1. Export CSV with columns: `scenario, avg_ms, p95_ms, p99_ms`.
+2. Generate chart using spreadsheet or plotting tool.
+
+## 5) Variability + Limits
+
+Include a short note that captures:
+- **Run-to-run variance** (std dev or range) and potential causes (GC, background load).
+- **Measurement limits** (sample count too low for P99, thermal throttling, shader differences).
+- **Any anomalies** (spike bursts, outlier runs, unexpected CPU/GPU saturation).


### PR DESCRIPTION
### Motivation

- Provide a standardized methodology to measure frametime stability (focus on P95/P99) to ensure consistent, comparable results across runs.
- Define a small set of reproducible scenarios (combat, redstone, megabase) that exercise common sources of frametime variance.
- Ensure measurement reports include the exact hardware/configuration and a repeatable reporting template (tables + graphs).

### Description

- Add `docs/benchmarking.md` documenting tools (Spark/VisualVM/overlays), warm-up/measurement/cooldown timings, and required environment details.
- Define three reproducible scenarios: Scenario A (Combat with mobs), Scenario B (Redstone tick-heavy), and Scenario C (Megabase with entities) with explicit repro steps and measurement windows.
- Specify configuration items to record per run (mods, shaders, render/simulation distance, NOZH config) and the data to collect (`avg`, `p95`, `p99`, spike count, samples).
- Provide a results template with a per-scenario table and graphing options (Mermaid or CSV export) plus guidance on variability and measurement limits.

### Testing

- No automated tests were run because this is a documentation-only change.
- Existing CI/unit tests were not executed as part of this change and are expected to be unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69581c962804832d978308d147911ee9)