### PR TITLE
Handle ResetCapability in governor loop and always update governor action state

### DIFF
--- a/src/main/java/dev/nozh/core/governor/GovernorRunner.java
+++ b/src/main/java/dev/nozh/core/governor/GovernorRunner.java
@@ -153,28 +153,31 @@ public final class GovernorRunner {
         logger.info("Governor decision: " + decision.reason());
 
         // Dispatch via ActionBus
+        Command cmd;
         if (decision.targetValue() != null) {
-            Command cmd = new Command.ApplyCapability(
+            cmd = new Command.ApplyCapability(
                     decision.capabilityId(),
                     decision.targetValue());
+        } else {
+            cmd = new Command.ResetCapability(decision.capabilityId());
+        }
 
-            actionBus.dispatch(cmd, report -> {
-                // Log result only, no logic
-                if (report.succeeded()) {
-                    logger.info("Governor action succeeded");
-                    // Reset predictor after successful action
-                    predictiveAnalyzer.reset();
-                } else {
-                    logger.warn("Governor action failed: " + report.error().orElse("unknown"));
-                }
-            });
-
-            // Update state after action dispatch
-            try {
-                stateStore.update(currentState -> currentState.withGovernorAction(now));
-            } catch (Exception e) {
-                logger.warn("Failed to update state after governor action: " + e.getMessage());
+        actionBus.dispatch(cmd, report -> {
+            // Log result only, no logic
+            if (report.succeeded()) {
+                logger.info("Governor action succeeded");
+                // Reset predictor after successful action
+                predictiveAnalyzer.reset();
+            } else {
+                logger.warn("Governor action failed: " + report.error().orElse("unknown"));
             }
+        });
+
+        // Update state after action dispatch
+        try {
+            stateStore.update(currentState -> currentState.withGovernorAction(now));
+        } catch (Exception e) {
+            logger.warn("Failed to update state after governor action: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the governor can issue reset commands when a selected action has no explicit `targetValue` so capabilities are reverted as needed.
- Prevent leaving capabilities in an unintended state by always recording that the governor acted (to maintain cooldown/observation invariants).
- Simplify dispatch logic to treat apply and reset commands uniformly and centralize logging/predictor reset behavior.
- Align `GovernorRunner` behavior with existing `Command.ResetCapability` handling elsewhere in the bus/processor layers.

### Description
- Updated `src/main/java/dev/nozh/core/governor/GovernorRunner.java` to construct a `Command` that is either `ApplyCapability` (when `targetValue != null`) or `ResetCapability` (otherwise).
- Unified `actionBus.dispatch(cmd, ...)` call so both apply and reset commands go through the same dispatch and logging/predictive reset flow.
- Moved the `stateStore.update(currentState -> currentState.withGovernorAction(now))` call to always run after dispatch to ensure cooldown timing is recorded.
- Minor refactor to reduce duplicated code in the decision dispatch branch.

### Testing
- Attempted to compile Java sources with `./gradlew compileJava`, but the Gradle wrapper download failed due to a proxy returning `HTTP/1.1 403 Forbidden` and the build did not run.
- No other automated tests were executed as the build could not complete due to the proxy issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69581eb05314832d8306e7f7424e878a)