### PR TITLE
Introduce ConfigSyncService and move config→RuntimeState sync out of StateStore

### DIFF
--- a/src/main/java/dev/nozh/client/NozhModClient.java
+++ b/src/main/java/dev/nozh/client/NozhModClient.java
@@ -5,6 +5,7 @@ import dev.nozh.core.NozhLogger;
 import dev.nozh.core.bus.ActionBus;
 import dev.nozh.core.bus.StandardActionProcessor;
 import dev.nozh.core.config.ConfigManager;
+import dev.nozh.core.config.ConfigSyncService;
 import dev.nozh.core.capability.ProviderRegistry;
 import dev.nozh.core.governor.GovernorRunner;
 import dev.nozh.core.matrix.ActionSuccessTracker;
@@ -35,6 +36,7 @@ public class NozhModClient implements ClientModInitializer {
     private static GovernorRunner governorRunner;
     private static ActionBus actionBus;
     private static StateStore stateStore;
+    private static ConfigSyncService configSyncService;
     private static dev.nozh.core.intelligence.SessionLearning sessionLearning;
 
     private static int tickCounter = 0;
@@ -60,6 +62,7 @@ public class NozhModClient implements ClientModInitializer {
 
         // 2. Get StateStore singleton
         stateStore = StateStore.getInstance();
+        configSyncService = ConfigSyncService.start(stateStore);
 
         // 3. Create MinecraftOptionsAdapter
         MinecraftOptionsAdapter optionsAdapter = new ProductionMinecraftOptionsAdapter();

--- a/src/main/java/dev/nozh/core/config/ConfigSyncService.java
+++ b/src/main/java/dev/nozh/core/config/ConfigSyncService.java
@@ -1,0 +1,42 @@
+package dev.nozh.core.config;
+
+import dev.nozh.NozhConstants;
+import dev.nozh.core.state.RuntimeState;
+import dev.nozh.core.state.StateStore;
+
+/**
+ * Dedicated service to synchronize config changes into RuntimeState.
+ */
+public final class ConfigSyncService {
+
+    private final StateStore stateStore;
+    private final ConfigListener listener;
+
+    private ConfigSyncService(StateStore stateStore) {
+        this.stateStore = stateStore;
+        this.listener = config -> stateStore.update(state -> state.withConfig(config));
+    }
+
+    public static ConfigSyncService start(StateStore stateStore) {
+        ConfigSyncService service = new ConfigSyncService(stateStore);
+        service.syncFromConfig();
+        ConfigManager.addListener(service.listener);
+        return service;
+    }
+
+    public void stop() {
+        ConfigManager.removeListener(listener);
+    }
+
+    private void syncFromConfig() {
+        NozhConfig config = ConfigManager.getConfig();
+        if (config == null) {
+            NozhConstants.LOGGER.warn("Config sync skipped: config is null");
+            return;
+        }
+        RuntimeState runtimeState = RuntimeState.fromConfig(config);
+        stateStore.replaceState(runtimeState);
+        NozhConstants.LOGGER.info("RuntimeState synchronized from config (version {})",
+                runtimeState.stateVersion());
+    }
+}

--- a/src/main/java/dev/nozh/core/state/StateStore.java
+++ b/src/main/java/dev/nozh/core/state/StateStore.java
@@ -51,12 +51,10 @@ public final class StateStore {
     private int lastPersistedHash; // For dirty flag optimization
 
     private StateStore() {
-        // Initialize from config to respect user preferences
-        this.currentState = RuntimeState.fromConfig(dev.nozh.core.config.ConfigManager.getConfig());
+        this.currentState = RuntimeState.defaults();
         this.lastPersistedHash = currentState.hashCode();
-        NozhConstants.LOGGER.info("StateStore initialized from config (version {})",
+        NozhConstants.LOGGER.info("StateStore initialized with defaults (version {})",
                 currentState.stateVersion());
-        dev.nozh.core.config.ConfigManager.addListener(config -> update(state -> state.withConfig(config)));
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Centralize the config → runtime state synchronization into a single dedicated service to respect the invariant that only one component updates `RuntimeState` from config.
- Remove Minecraft/config dependencies from the pure `StateStore` to maintain Contract 1 (StateStore purity).
- Ensure runtime state is initialized deterministically and that config changes are applied only via a controlled listener.

### Description
- `StateStore` no longer initializes from `ConfigManager.getConfig()` nor registers a config listener and now initializes with `RuntimeState.defaults()` instead.
- Added `dev.nozh.core.config.ConfigSyncService` which performs the initial sync (`replaceState(RuntimeState.fromConfig(config))`) and registers a listener that performs `stateStore.update(state -> state.withConfig(config))` on subsequent config changes.
- `NozhModClient` now starts the sync service during startup (after `ConfigManager.load()`) via `ConfigSyncService.start(stateStore)`.
- Reviewed UI/command paths to continue using `ConfigManager.saveAndNotify()` for config writes so they do not directly mutate `RuntimeState`.

### Testing
- No automated tests were executed for this change.
- The change set compiles-level modifications were applied to three files: `StateStore`, `ConfigSyncService` (new), and `NozhModClient`.
- Manual review ensured the config listener was removed from `StateStore` and that `ConfigSyncService` registers the listener.
- No runtime integration tests were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958aa8e53f0832d8168e5a25b04d89a)