### PR TITLE
Add pending suggestion flow, ModeController, and `/nozh apply` command

### DIFF
--- a/src/main/java/dev/nozh/client/NozhCommands.java
+++ b/src/main/java/dev/nozh/client/NozhCommands.java
@@ -4,9 +4,15 @@ import dev.nozh.NozhConstants;
 import dev.nozh.core.compat.CompatService;
 import dev.nozh.core.config.ConfigManager;
 import dev.nozh.core.config.NozhConfig;
+import dev.nozh.core.bus.ActionBus;
+import dev.nozh.core.bus.Command;
+import dev.nozh.core.bus.CapabilityValue;
 import dev.nozh.core.safety.CrashLoopGuard;
 import dev.nozh.core.safety.StateManager;
 import dev.nozh.core.safety.NozhState;
+import dev.nozh.core.state.PendingAction;
+import dev.nozh.core.state.RuntimeState;
+import dev.nozh.core.state.StateStore;
 import dev.nozh.core.util.NozhText;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -54,6 +60,11 @@ public final class NozhCommands {
                             .then(ClientCommandManager.literal("history")
                                     .executes(context -> {
                                         runHistory(context);
+                                        return 1;
+                                    }))
+                            .then(ClientCommandManager.literal("apply")
+                                    .executes(context -> {
+                                        runApply(context.getSource());
                                         return 1;
                                     }))
                             .then(ClientCommandManager.literal("enable")
@@ -200,6 +211,20 @@ public final class NozhCommands {
                 .append(Text.translatable(modeKey).styled(s -> s.withColor(color))));
         ctx.getSource().sendFeedback(Text.translatable("nozh.status.uptime", uptimeSec));
         ctx.getSource().sendFeedback(Text.translatable("nozh.status.target", config.targetFps));
+
+        StateStore stateStore = NozhModClient.getStateStore();
+        if (stateStore != null) {
+            RuntimeState runtimeState = stateStore.snapshotSafe();
+            if (runtimeState.pendingSuggestion().isPresent()) {
+                PendingAction pending = runtimeState.pendingSuggestion().get();
+                ctx.getSource().sendFeedback(NozhText.warning(
+                        "Suggestion pending: " + formatPendingAction(pending) + " (/nozh apply)"));
+            } else if (runtimeState.pendingAction().isPresent()) {
+                PendingAction pending = runtimeState.pendingAction().get();
+                ctx.getSource().sendFeedback(NozhText.info(
+                        "Action pending evaluation: " + formatPendingAction(pending)));
+            }
+        }
     }
 
     private static void runHistory(CommandContext<FabricClientCommandSource> ctx) {
@@ -267,5 +292,69 @@ public final class NozhCommands {
         ConfigManager.saveAndNotify();
 
         source.sendFeedback(Text.translatable("nozh.disable.success"));
+    }
+
+    private static void runApply(FabricClientCommandSource source) {
+        StateStore stateStore = NozhModClient.getStateStore();
+        ActionBus actionBus = NozhModClient.getActionBus();
+        if (stateStore == null || actionBus == null) {
+            source.sendFeedback(NozhText.error("NOZH not initialized"));
+            return;
+        }
+
+        RuntimeState state = stateStore.snapshotSafe();
+        if (state.pendingSuggestion().isEmpty()) {
+            source.sendFeedback(NozhText.warning("No pending suggestion to apply"));
+            return;
+        }
+
+        PendingAction pending = state.pendingSuggestion().get();
+        Command cmd = new Command.ApplyCapability(pending.capability(), pending.newValue());
+
+        actionBus.dispatchUserCommand(cmd, report -> {
+            if (report.succeeded()) {
+                source.sendFeedback(NozhText.success("Suggestion applied"));
+            } else {
+                source.sendFeedback(NozhText.error(
+                        "Failed to apply suggestion: " + report.error().orElse("unknown")));
+                try {
+                    stateStore.update(RuntimeState::withPendingActionCleared);
+                } catch (Exception ignored) {
+                }
+            }
+        });
+
+        try {
+            stateStore.update(currentState -> currentState.withAppliedSuggestion(System.currentTimeMillis(), pending));
+        } catch (Exception e) {
+            source.sendFeedback(NozhText.error("Failed to update state for suggestion"));
+        }
+    }
+
+    private static String formatPendingAction(PendingAction pending) {
+        String value = formatCapabilityValue(pending.newValue());
+        if (value.isEmpty()) {
+            return pending.capability().toString();
+        }
+        return pending.capability() + "=" + value;
+    }
+
+    private static String formatCapabilityValue(CapabilityValue value) {
+        if (value == null) {
+            return "";
+        }
+        if (value instanceof CapabilityValue.IntValue intValue) {
+            return Integer.toString(intValue.value());
+        }
+        if (value instanceof CapabilityValue.EnumValue enumValue) {
+            return enumValue.name();
+        }
+        if (value instanceof CapabilityValue.BoolValue boolValue) {
+            return Boolean.toString(boolValue.value());
+        }
+        if (value instanceof CapabilityValue.FloatValue floatValue) {
+            return Float.toString(floatValue.value());
+        }
+        return value.toString();
     }
 }

--- a/src/main/java/dev/nozh/core/bus/ActionBus.java
+++ b/src/main/java/dev/nozh/core/bus/ActionBus.java
@@ -98,11 +98,33 @@ public final class ActionBus {
      * @param callback Result callback (may be called from tick thread)
      */
     public void dispatch(Command command, Consumer<CommandExecutionReport> callback) {
+        dispatch(command, callback, false);
+    }
+
+    /**
+     * Dispatch a user-confirmed command (bypasses auto-tuning gating).
+     */
+    public void dispatchUserCommand(Command command, Consumer<CommandExecutionReport> callback) {
+        dispatch(command, callback, true);
+    }
+
+    private void dispatch(Command command, Consumer<CommandExecutionReport> callback, boolean userInitiated) {
         long queuedAt = System.currentTimeMillis();
 
         synchronized (commandQueue) {
             // Validate against current state (injected provider, not StateStore singleton)
             RuntimeState state = stateProvider.get();
+            if (!userInitiated && !state.autoTuning() && isAutoCapabilityCommand(command)) {
+                CommandExecutionReport report = createRejectedReport(
+                        command,
+                        queuedAt,
+                        "Auto-tuning disabled: automatic actions blocked");
+                callback.accept(report);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Command rejected (auto-tuning disabled): " + command.id());
+                }
+                return;
+            }
             ValidationResult validation = CommandValidator.validate(command, state);
 
             if (validation.isInvalid()) {
@@ -242,6 +264,12 @@ public final class ActionBus {
             return ((Command.PreviewCapability) command).capability();
         }
         return null; // Benchmark has no capability
+    }
+
+    private boolean isAutoCapabilityCommand(Command command) {
+        return command instanceof Command.ApplyCapability
+                || command instanceof Command.ResetCapability
+                || command instanceof Command.PreviewCapability;
     }
 
     /**

--- a/src/main/java/dev/nozh/core/governor/GovernorRunner.java
+++ b/src/main/java/dev/nozh/core/governor/GovernorRunner.java
@@ -115,6 +115,11 @@ public final class GovernorRunner {
             return;
         }
 
+        if (state.pendingSuggestion().isPresent()) {
+            logger.debug("Pending suggestion awaiting confirmation");
+            return;
+        }
+
         // Feed predictor
         if (state.avgFrametimeMs() > 0) {
             predictiveAnalyzer.addSample(state.avgFrametimeMs());
@@ -132,6 +137,7 @@ public final class GovernorRunner {
 
         GovernorMode mode = determineMode(state);
         String bound = detectBound(state);
+        ModeController modeController = ModeController.forMode(mode);
 
         // 3. Detect performance bound from telemetry
         String currentBound = detectBound(state);
@@ -179,6 +185,16 @@ public final class GovernorRunner {
             Command cmd = new Command.ApplyCapability(
                     decision.capabilityId(),
                     decision.targetValue());
+
+            if (modeController.requiresUserConfirmation()) {
+                try {
+                    stateStore.update(currentState -> currentState.withPendingSuggestion(pending));
+                    logger.info("Governor suggestion awaiting confirmation: " + actionSummary);
+                } catch (Exception e) {
+                    logger.warn("Failed to store pending suggestion: " + e.getMessage());
+                }
+                return;
+            }
 
             actionBus.dispatch(cmd, report -> {
                 if (report.succeeded()) {

--- a/src/main/java/dev/nozh/core/governor/ModeController.java
+++ b/src/main/java/dev/nozh/core/governor/ModeController.java
@@ -1,0 +1,27 @@
+package dev.nozh.core.governor;
+
+/**
+ * Mode controller wrapper (Contract 6).
+ *
+ * Encapsulates ModePolicy so callers don't need to reason about policy shape.
+ */
+public final class ModeController {
+
+    private final ModePolicy policy;
+
+    private ModeController(ModePolicy policy) {
+        this.policy = policy;
+    }
+
+    public static ModeController forMode(GovernorMode mode) {
+        return new ModeController(ModePolicy.forMode(mode));
+    }
+
+    public ModePolicy policy() {
+        return policy;
+    }
+
+    public boolean requiresUserConfirmation() {
+        return policy.requiresUserConfirmation();
+    }
+}

--- a/src/main/java/dev/nozh/core/state/RuntimeState.java
+++ b/src/main/java/dev/nozh/core/state/RuntimeState.java
@@ -36,6 +36,7 @@ public record RuntimeState(
         String benchmarkValidity,
         long benchmarkStartTimestamp,
         Optional<PendingAction> pendingAction,
+        Optional<PendingAction> pendingSuggestion,
         int pendingActionsCount,
         int executionHistorySize,
         int lastSnapshotHistorySize,
@@ -51,7 +52,7 @@ public record RuntimeState(
         int stateVersion,
         dev.nozh.core.context.Scenario currentScenario,
         double scenarioConfidence) {
-    private static final int CURRENT_VERSION = 3; // Bump version
+    private static final int CURRENT_VERSION = 4; // Bump version
 
     /**
      * Create default initial state.
@@ -69,6 +70,7 @@ public record RuntimeState(
                 "NONE", // benchmarkValidity
                 0L, // benchmarkStartTimestamp
                 Optional.empty(), // pendingAction
+                Optional.empty(), // pendingSuggestion
                 0, // pendingActionsCount
                 0, // executionHistorySize
                 0, // lastSnapshotHistorySize
@@ -94,10 +96,30 @@ public record RuntimeState(
                 timestamp, // governorLastActionTimestamp
                 benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
                 Optional.of(pending),
+                pendingSuggestion,
                 pendingAction.isPresent() ? pendingActionsCount + 1 : 1,
                 executionHistorySize + 1, // increment history
                 lastSnapshotHistorySize,
                 sessionChangesCount + 1, // increment changes
+                avgFrametimeMs, p95FrametimeMs, tickTimeAvg, tickTimeP95, spikeCount,
+                lastDecisionReason, lastDecisionTimestamp,
+                sessionStartTime, stateVersion,
+                currentScenario, scenarioConfidence);
+    }
+
+    public RuntimeState withAppliedSuggestion(long timestamp, PendingAction pending) {
+        return new RuntimeState(
+                enabled, safeMode, autoTuning, debugLogs,
+                governorDisabled,
+                true,
+                timestamp,
+                benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
+                Optional.of(pending),
+                Optional.empty(),
+                pendingAction.isPresent() ? pendingActionsCount + 1 : 1,
+                executionHistorySize + 1,
+                lastSnapshotHistorySize,
+                sessionChangesCount + 1,
                 avgFrametimeMs, p95FrametimeMs, tickTimeAvg, tickTimeP95, spikeCount,
                 lastDecisionReason, lastDecisionTimestamp,
                 sessionStartTime, stateVersion,
@@ -115,6 +137,7 @@ public record RuntimeState(
                 governorLastActionTimestamp,
                 benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
                 Optional.empty(),
+                pendingSuggestion,
                 0,
                 executionHistorySize,
                 lastSnapshotHistorySize,
@@ -141,7 +164,7 @@ public record RuntimeState(
                 running ? true : governorDisabled, // disable governor during benchmark
                 governorCooldownActive, governorLastActionTimestamp,
                 running, validity, startTime,
-                pendingAction, pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
+                pendingAction, pendingSuggestion, pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
                 sessionChangesCount,
                 avgFrametimeMs, p95FrametimeMs, tickTimeAvg, tickTimeP95, spikeCount,
                 lastDecisionReason, lastDecisionTimestamp,
@@ -157,7 +180,7 @@ public record RuntimeState(
                 enabled, safeMode, autoTuning, debugLogs,
                 governorDisabled, governorCooldownActive, governorLastActionTimestamp,
                 benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
-                pendingAction, pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
+                pendingAction, pendingSuggestion, pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
                 sessionChangesCount,
                 avg, p95, tickAvg, tickP95, spikes,
                 lastDecisionReason, lastDecisionTimestamp,
@@ -175,7 +198,7 @@ public record RuntimeState(
                 false, // governorCooldownActive = false
                 governorLastActionTimestamp,
                 benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
-                pendingAction, pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
+                pendingAction, pendingSuggestion, pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
                 sessionChangesCount,
                 avgFrametimeMs, p95FrametimeMs, tickTimeAvg, tickTimeP95, spikeCount,
                 lastDecisionReason, lastDecisionTimestamp,
@@ -191,7 +214,7 @@ public record RuntimeState(
                 enabled, safeMode, autoTuning, debugLogs,
                 governorDisabled, governorCooldownActive, governorLastActionTimestamp,
                 benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
-                pendingAction, pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
+                pendingAction, pendingSuggestion, pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
                 sessionChangesCount,
                 avgFrametimeMs, p95FrametimeMs, tickTimeAvg, tickTimeP95, spikeCount,
                 lastDecisionReason, lastDecisionTimestamp,
@@ -217,6 +240,7 @@ public record RuntimeState(
                 governorDisabled, governorCooldownActive, governorLastActionTimestamp,
                 benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
                 pendingAction,
+                pendingSuggestion,
                 pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
                 sessionChangesCount,
                 avgFrametimeMs, p95FrametimeMs, tickTimeAvg, tickTimeP95, spikeCount,
@@ -234,11 +258,42 @@ public record RuntimeState(
                 governorDisabled, governorCooldownActive, governorLastActionTimestamp,
                 benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
                 pendingAction,
+                pendingSuggestion,
                 pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
                 sessionChangesCount,
                 avgFrametimeMs, p95FrametimeMs, tickTimeAvg, tickTimeP95, spikeCount,
                 reason != null ? reason : "",
                 timestamp,
+                sessionStartTime, stateVersion,
+                currentScenario, scenarioConfidence);
+    }
+
+    public RuntimeState withPendingSuggestion(PendingAction suggestion) {
+        return new RuntimeState(
+                enabled, safeMode, autoTuning, debugLogs,
+                governorDisabled, governorCooldownActive, governorLastActionTimestamp,
+                benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
+                pendingAction,
+                Optional.of(suggestion),
+                pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
+                sessionChangesCount,
+                avgFrametimeMs, p95FrametimeMs, tickTimeAvg, tickTimeP95, spikeCount,
+                lastDecisionReason, lastDecisionTimestamp,
+                sessionStartTime, stateVersion,
+                currentScenario, scenarioConfidence);
+    }
+
+    public RuntimeState withPendingSuggestionCleared() {
+        return new RuntimeState(
+                enabled, safeMode, autoTuning, debugLogs,
+                governorDisabled, governorCooldownActive, governorLastActionTimestamp,
+                benchmarkRunning, benchmarkValidity, benchmarkStartTimestamp,
+                pendingAction,
+                Optional.empty(),
+                pendingActionsCount, executionHistorySize, lastSnapshotHistorySize,
+                sessionChangesCount,
+                avgFrametimeMs, p95FrametimeMs, tickTimeAvg, tickTimeP95, spikeCount,
+                lastDecisionReason, lastDecisionTimestamp,
                 sessionStartTime, stateVersion,
                 currentScenario, scenarioConfidence);
     }
@@ -259,6 +314,7 @@ public record RuntimeState(
                 "NONE", // benchmarkValidity
                 0L, // benchmarkStartTimestamp
                 Optional.empty(), // pendingAction
+                Optional.empty(), // pendingSuggestion
                 0, // pendingActionsCount
                 0, // executionHistorySize
                 0, // lastSnapshotHistorySize

--- a/src/main/java/dev/nozh/core/state/StateMigrationRegistry.java
+++ b/src/main/java/dev/nozh/core/state/StateMigrationRegistry.java
@@ -16,10 +16,11 @@ import java.util.Optional;
  * - Version 1 (initial): RuntimeState with basic fields
  * - Version 2 (adds benchmarkRunning): Migrator adds benchmarkRunning=false
  * - Version 3 (adds confidence tracking): Migrator adds confidence fields
+ * - Version 4 (adds pending suggestion): Migrator adds suggestion field
  */
 public final class StateMigrationRegistry {
 
-    private static final int CURRENT_VERSION = 3; // Current state version
+    private static final int CURRENT_VERSION = 4; // Current state version
 
     private final Map<Integer, StateMigrator> migrators = new HashMap<>();
 
@@ -55,6 +56,7 @@ public final class StateMigrationRegistry {
                     "NONE", // benchmarkValidity default
                     0L, // benchmarkStartTimestamp default
                     Optional.empty(), // pendingAction default
+                    Optional.empty(), // pendingSuggestion default
                     0, // pendingActionsCount default
                     oldState.executionHistorySize(),
                     oldState.lastSnapshotHistorySize(),
@@ -66,10 +68,39 @@ public final class StateMigrationRegistry {
                     oldState.spikeCount(),
                     "", 0L, // lastDecisionReason, lastDecisionTimestamp default
                     oldState.sessionStartTime(),
-                    3, // Target version is 3
+                    4, // Target version is 4
                     dev.nozh.core.context.Scenario.STANDARD,
                     0.5);
         });
+
+        registerMigrator(3, oldState -> new RuntimeState(
+                oldState.enabled(),
+                oldState.safeMode(),
+                oldState.autoTuning(),
+                oldState.debugLogs(),
+                oldState.governorDisabled(),
+                oldState.governorCooldownActive(),
+                oldState.governorLastActionTimestamp(),
+                oldState.benchmarkRunning(),
+                oldState.benchmarkValidity(),
+                oldState.benchmarkStartTimestamp(),
+                oldState.pendingAction(),
+                Optional.empty(), // pendingSuggestion default
+                oldState.pendingActionsCount(),
+                oldState.executionHistorySize(),
+                oldState.lastSnapshotHistorySize(),
+                oldState.sessionChangesCount(),
+                oldState.avgFrametimeMs(),
+                oldState.p95FrametimeMs(),
+                oldState.tickTimeAvg(),
+                oldState.tickTimeP95(),
+                oldState.spikeCount(),
+                oldState.lastDecisionReason(),
+                oldState.lastDecisionTimestamp(),
+                oldState.sessionStartTime(),
+                4,
+                oldState.currentScenario(),
+                oldState.scenarioConfidence()));
 
         NozhConstants.LOGGER.debug("StateMigrationRegistry initialized (current version: {})", CURRENT_VERSION);
     }

--- a/src/test/java/dev/nozh/core/bus/ActionBusIntegrationTest.java
+++ b/src/test/java/dev/nozh/core/bus/ActionBusIntegrationTest.java
@@ -2,6 +2,7 @@ package dev.nozh.core.bus;
 
 import dev.nozh.core.NoOpLogger;
 import dev.nozh.core.state.RuntimeState;
+import dev.nozh.core.state.TestStates;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -22,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ActionBusIntegrationTest {
 
         // Fake state provider for tests (Contract 2 purity)
-        private static final RuntimeState FAKE_STATE = RuntimeState.defaults();
+        private static final RuntimeState FAKE_STATE = TestStates.autoTuningEnabled();
 
         @Test
         void testDispatchTickProcessorFlow() {

--- a/src/test/java/dev/nozh/core/bus/ChaosBasicTest.java
+++ b/src/test/java/dev/nozh/core/bus/ChaosBasicTest.java
@@ -2,6 +2,7 @@ package dev.nozh.core.bus;
 
 import dev.nozh.core.NoOpLogger;
 import dev.nozh.core.state.RuntimeState;
+import dev.nozh.core.state.TestStates;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -29,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class ChaosBasicTest {
 
-    private static final RuntimeState FAKE_STATE = RuntimeState.defaults();
+    private static final RuntimeState FAKE_STATE = TestStates.autoTuningEnabled();
 
     @Test
     void testExecutorAlwaysThrows() {

--- a/src/test/java/dev/nozh/core/bus/DeterminismTest.java
+++ b/src/test/java/dev/nozh/core/bus/DeterminismTest.java
@@ -2,6 +2,7 @@ package dev.nozh.core.bus;
 
 import dev.nozh.core.NoOpLogger;
 import dev.nozh.core.state.RuntimeState;
+import dev.nozh.core.state.TestStates;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -22,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class DeterminismTest {
 
-    private static final RuntimeState FAKE_STATE = RuntimeState.defaults();
+    private static final RuntimeState FAKE_STATE = TestStates.autoTuningEnabled();
 
     @Test
     void testRepeatedExecutionIsDeterministic() {

--- a/src/test/java/dev/nozh/core/state/StateInvariantValidatorTest.java
+++ b/src/test/java/dev/nozh/core/state/StateInvariantValidatorTest.java
@@ -41,6 +41,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
+                                state.pendingSuggestion(),
                                 state.pendingActionsCount(),
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -78,6 +79,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
+                                state.pendingSuggestion(),
                                 state.pendingActionsCount(),
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -116,6 +118,7 @@ class StateInvariantValidatorTest {
                                 "NONE", // benchmarkValidity
                                 System.currentTimeMillis(),
                                 base.pendingAction(),
+                                base.pendingSuggestion(),
                                 base.pendingActionsCount(),
                                 base.executionHistorySize(),
                                 base.lastSnapshotHistorySize(),
@@ -153,6 +156,7 @@ class StateInvariantValidatorTest {
                                 "NONE", // benchmarkValidity
                                 System.currentTimeMillis(),
                                 state.pendingAction(),
+                                state.pendingSuggestion(),
                                 state.pendingActionsCount(),
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -187,6 +191,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
+                                state.pendingSuggestion(),
                                 3, // pendingActionsCount > 0
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -224,6 +229,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
+                                state.pendingSuggestion(),
                                 3, // pendingActionsCount > 0
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -260,6 +266,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
+                                state.pendingSuggestion(),
                                 state.pendingActionsCount(),
                                 5, // executionHistorySize = 5
                                 10, // lastSnapshotHistorySize = 10 (VIOLATION: decreased)
@@ -299,6 +306,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
+                                state.pendingSuggestion(),
                                 state.pendingActionsCount(),
                                 15, // executionHistorySize = 15
                                 10, // lastSnapshotHistorySize = 10 (OK: increased)
@@ -336,6 +344,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 System.currentTimeMillis(),
                                 state.pendingAction(),
+                                state.pendingSuggestion(),
                                 5, // pendingActionsCount > 0 (VIOLATION 3)
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -383,6 +392,7 @@ class StateInvariantValidatorTest {
                                 base.benchmarkValidity(),
                                 base.benchmarkStartTimestamp(),
 
+                                Optional.<PendingAction>empty(),
                                 Optional.<PendingAction>empty(),
                                 0,
 

--- a/src/test/java/dev/nozh/core/state/TestStates.java
+++ b/src/test/java/dev/nozh/core/state/TestStates.java
@@ -1,0 +1,39 @@
+package dev.nozh.core.state;
+
+public final class TestStates {
+
+    private TestStates() {
+    }
+
+    public static RuntimeState autoTuningEnabled() {
+        RuntimeState state = RuntimeState.defaults();
+        return new RuntimeState(
+                state.enabled(),
+                state.safeMode(),
+                true,
+                state.debugLogs(),
+                state.governorDisabled(),
+                state.governorCooldownActive(),
+                state.governorLastActionTimestamp(),
+                state.benchmarkRunning(),
+                state.benchmarkValidity(),
+                state.benchmarkStartTimestamp(),
+                state.pendingAction(),
+                state.pendingSuggestion(),
+                state.pendingActionsCount(),
+                state.executionHistorySize(),
+                state.lastSnapshotHistorySize(),
+                state.sessionChangesCount(),
+                state.avgFrametimeMs(),
+                state.p95FrametimeMs(),
+                state.tickTimeAvg(),
+                state.tickTimeP95(),
+                state.spikeCount(),
+                state.lastDecisionReason(),
+                state.lastDecisionTimestamp(),
+                state.sessionStartTime(),
+                state.stateVersion(),
+                state.currentScenario(),
+                state.scenarioConfidence());
+    }
+}


### PR DESCRIPTION
### Motivation

- Allow the governor to surface suggestions that require user confirmation instead of immediately applying them. 
- Prevent automatic capability changes when auto-tuning is disabled so HUD/commands can control acceptance. 
- Provide a small abstraction over `ModePolicy` so callers can ask whether confirmation is required without reasoning about policy internals. 
- Expose a user command to accept pending suggestions from the HUD/CLI.

### Description

- Add `ModeController` as a thin wrapper around `ModePolicy` with `requiresUserConfirmation()` and `forMode()` helpers (`src/main/java/dev/nozh/core/governor/ModeController.java`).
- Introduce a new `pendingSuggestion` field and helpers in `RuntimeState` (`withPendingSuggestion`, `withPendingSuggestionCleared`, `withAppliedSuggestion`) and bump state version to `4`, plus migration entries in `StateMigrationRegistry` (`src/main/java/dev/nozh/core/state/RuntimeState.java`, `StateMigrationRegistry.java`).
- Gate automatic capability dispatch in `ActionBus` so non-user-initiated apply/reset/preview commands are rejected when `RuntimeState.autoTuning()==false`, and add `dispatchUserCommand` to bypass the gate (`src/main/java/dev/nozh/core/bus/ActionBus.java`).
- Update `GovernorRunner` to create a pending suggestion when the selected `ModeController` requires confirmation instead of dispatching the command, and to pause while a suggestion awaits confirmation (`src/main/java/dev/nozh/core/governor/GovernorRunner.java`).
- Add `/nozh apply` command and status output to surface and accept pending suggestions, and wire state updates to mark suggestions as applied (`src/main/java/dev/nozh/client/NozhCommands.java`).
- Update unit/integration tests to use an `autoTuningEnabled` test state and include the new `pendingSuggestion` field (`src/test/...`), and add a small `TestStates` helper.

### Testing

- Updated tests: `ActionBusIntegrationTest`, `ChaosBasicTest`, `DeterminismTest`, and `StateInvariantValidatorTest` were modified to account for the `pendingSuggestion` field and to use `TestStates.autoTuningEnabled()`; no automated test run was performed in this rollout. 
- No automated tests were executed as part of this change (no test run requested), so success/failure results are not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958aa8d0fc4832d96e27c3291655c55)