### PR TITLE
Always run ScenarioDetector each tick; enrich Fabric detector and expose localized scenario + confidence in HUD

### DIFF
--- a/src/main/java/dev/nozh/core/context/Scenario.java
+++ b/src/main/java/dev/nozh/core/context/Scenario.java
@@ -24,5 +24,9 @@ public enum Scenario {
     MENU,
 
     /** Singleplayer world load or server join */
-    LOADING
+    LOADING;
+
+    public String translationKey() {
+        return "nozh.scenario." + name().toLowerCase();
+    }
 }

--- a/src/main/java/dev/nozh/core/governor/GovernorRunner.java
+++ b/src/main/java/dev/nozh/core/governor/GovernorRunner.java
@@ -75,6 +75,14 @@ public final class GovernorRunner {
     }
 
     public void onTick() {
+        dev.nozh.core.context.ScenarioSnapshot scenarioSnapshot = scenarioDetector.detect();
+        try {
+            stateStore.update(s -> s.withScenario(
+                    scenarioSnapshot.scenario(),
+                    scenarioSnapshot.confidence()));
+        } catch (Exception e) {
+            // Ignore update failure
+        }
         tickCounter++;
         if (tickCounter < POLL_INTERVAL_TICKS) {
             return;
@@ -86,16 +94,6 @@ public final class GovernorRunner {
     private void runGovernorLoop() {
         long now = System.currentTimeMillis();
         NozhConfig config = ConfigManager.getConfig();
-
-        // 1. Detect scenario and update state reference
-        dev.nozh.core.context.ScenarioSnapshot scenarioSnapshot = scenarioDetector.detect();
-        try {
-            stateStore.update(s -> s.withScenario(
-                    scenarioSnapshot.scenario(),
-                    scenarioSnapshot.confidence()));
-        } catch (Exception e) {
-            // Ignore update failure
-        }
 
         RuntimeState state = stateStore.snapshotSafe();
 

--- a/src/main/java/dev/nozh/core/ui/HudViewModel.java
+++ b/src/main/java/dev/nozh/core/ui/HudViewModel.java
@@ -53,6 +53,8 @@ public record HudViewModel(
                 String lastActionSummary,
                 String lastActionOutcome,
                 Scenario currentScenario,
+                String scenarioKey,
+                double scenarioConfidence,
 
                 // Benchmark status
                 boolean benchmarkRunning,
@@ -100,6 +102,8 @@ public record HudViewModel(
                         "",
                         "",
                         Scenario.STANDARD,
+                        Scenario.STANDARD.translationKey(),
+                        0.5,
                         false,
                         "NONE",
                         List.of(),

--- a/src/main/java/dev/nozh/core/ui/HudViewModelBuilder.java
+++ b/src/main/java/dev/nozh/core/ui/HudViewModelBuilder.java
@@ -4,6 +4,7 @@ import dev.nozh.core.bus.CommandLifecycle;
 import dev.nozh.core.capability.CapabilityProvider;
 import dev.nozh.core.capability.ProviderRegistry;
 import dev.nozh.core.capability.ProviderStatus;
+import dev.nozh.core.context.Scenario;
 import dev.nozh.core.issues.Issue;
 import dev.nozh.core.issues.IssueSeverity;
 import dev.nozh.core.preset.HardwareTier;
@@ -100,6 +101,9 @@ public final class HudViewModelBuilder {
 
         String lastActionSummary = "";
         String lastActionOutcome = "";
+        Scenario scenario = state.currentScenario() != null ? state.currentScenario() : Scenario.STANDARD;
+        String scenarioKey = scenario.translationKey();
+        double scenarioConfidence = state.scenarioConfidence();
 
         return new HudViewModel(
                 state.enabled(),
@@ -130,7 +134,9 @@ public final class HudViewModelBuilder {
                 directorSteward,
                 lastActionSummary,
                 lastActionOutcome,
-                state.currentScenario(),
+                scenario,
+                scenarioKey,
+                scenarioConfidence,
 
                 benchmarkRunning,
                 benchmarkValidity,

--- a/src/main/java/dev/nozh/fabric/context/FabricScenarioDetector.java
+++ b/src/main/java/dev/nozh/fabric/context/FabricScenarioDetector.java
@@ -9,6 +9,7 @@ import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.hit.HitResult;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -33,6 +34,8 @@ public class FabricScenarioDetector implements ScenarioDetector {
     private static final int ENTITY_CHECK_INTERVAL_TICKS = 20;
     private static final double ENTITY_RADIUS = 12.0;
     private static final int COMBAT_ENTITY_THRESHOLD = 8;
+    private static final double MOVEMENT_FAST_DISTANCE_SQ = 0.06 * 0.06;
+    private static final double MOVEMENT_SLOW_DISTANCE_SQ = 0.02 * 0.02;
 
     public FabricScenarioDetector() {
         this.client = MinecraftClient.getInstance();
@@ -52,7 +55,8 @@ public class FabricScenarioDetector implements ScenarioDetector {
 
         // Detect AFK (Stationary + No Input)
         Vec3d currentPos = player.getPos();
-        if (currentPos.squaredDistanceTo(lastPos) < 0.0001) {
+        double moveDistanceSq = currentPos.squaredDistanceTo(lastPos);
+        if (moveDistanceSq < 0.0001) {
             stationaryTicks++;
         } else {
             stationaryTicks = 0;
@@ -64,43 +68,71 @@ public class FabricScenarioDetector implements ScenarioDetector {
 
         int nearbyEntities = sampleNearbyEntities(player);
         double tpsDropConfidence = getTpsDropConfidence();
+        HitResult.Type targetType = getCrosshairTargetType();
+        boolean targetEntity = targetType == HitResult.Type.ENTITY;
+        boolean targetBlock = targetType == HitResult.Type.BLOCK;
+        boolean handSwinging = player.handSwinging;
+        boolean breakingBlock = client.interactionManager != null && client.interactionManager.isBreakingBlock();
 
         // Detect Mining (Underground + Pickaxe)
         boolean underground = currentPos.y < 50 && !client.world.isSkyVisible(player.getBlockPos());
         boolean holdingPickaxe = isPickaxe(player.getMainHandStack().getItem());
         boolean holdingWeapon = isWeapon(player.getMainHandStack().getItem());
-        boolean buildingCandidate = player.isCreative() && player.getMainHandStack().getItem() instanceof BlockItem;
+        boolean holdingBlockItem = player.getMainHandStack().getItem() instanceof BlockItem;
+        boolean buildingCandidate = holdingBlockItem;
+        boolean sprinting = player.isSprinting();
 
         double combatConfidence = 0.0;
         if (holdingWeapon) {
-            combatConfidence += 0.45;
+            combatConfidence += 0.35;
         }
         if (player.hurtTime > 0) {
-            combatConfidence += 0.35;
+            combatConfidence += 0.3;
         }
         if (nearbyEntities >= COMBAT_ENTITY_THRESHOLD) {
-            combatConfidence += 0.35;
+            combatConfidence += 0.3;
+        }
+        if (handSwinging) {
+            combatConfidence += 0.2;
+        }
+        if (targetEntity) {
+            combatConfidence += 0.2;
+        }
+        if (sprinting) {
+            combatConfidence += 0.1;
         }
         combatConfidence = clamp(combatConfidence + tpsDropConfidence * 0.1);
 
         double miningConfidence = 0.0;
         if (underground) {
-            miningConfidence += 0.35;
+            miningConfidence += 0.3;
         }
         if (holdingPickaxe) {
-            miningConfidence += 0.35;
+            miningConfidence += 0.25;
+        }
+        if (breakingBlock) {
+            miningConfidence += 0.25;
+        }
+        if (holdingPickaxe && (handSwinging || targetBlock)) {
+            miningConfidence += 0.2;
         }
         if (!inputRecent && stationaryTicks > 40) {
-            miningConfidence += 0.15;
+            miningConfidence += 0.1;
         }
         miningConfidence = clamp(miningConfidence + tpsDropConfidence * 0.05);
 
         double buildingConfidence = 0.0;
         if (buildingCandidate) {
-            buildingConfidence += 0.7;
+            buildingConfidence += 0.4;
+        }
+        if (holdingBlockItem && (handSwinging || targetBlock)) {
+            buildingConfidence += 0.25;
+        }
+        if (player.isCreative()) {
+            buildingConfidence += 0.15;
         }
         if (inputRecent) {
-            buildingConfidence += 0.15;
+            buildingConfidence += 0.1;
         }
         buildingConfidence = clamp(buildingConfidence);
 
@@ -116,7 +148,18 @@ public class FabricScenarioDetector implements ScenarioDetector {
         }
         afkConfidence = clamp(afkConfidence - tpsDropConfidence * 0.2);
 
+        double movementConfidence = 0.0;
+        if (moveDistanceSq > MOVEMENT_SLOW_DISTANCE_SQ) {
+            movementConfidence += 0.15;
+        }
+        if (moveDistanceSq > MOVEMENT_FAST_DISTANCE_SQ) {
+            movementConfidence += 0.2;
+        }
+        if (sprinting) {
+            movementConfidence += 0.15;
+        }
         double standardConfidence = inputRecent ? 0.55 : 0.4;
+        standardConfidence = clamp(standardConfidence + movementConfidence - tpsDropConfidence * 0.05);
 
         dev.nozh.core.context.Scenario scenario = dev.nozh.core.context.Scenario.STANDARD;
         double confidence = standardConfidence;
@@ -169,6 +212,13 @@ public class FabricScenarioDetector implements ScenarioDetector {
         return item == Items.DIAMOND_SWORD ||
                 item == Items.NETHERITE_SWORD ||
                 item == Items.NETHERITE_AXE;
+    }
+
+    private HitResult.Type getCrosshairTargetType() {
+        if (client.crosshairTarget == null) {
+            return HitResult.Type.MISS;
+        }
+        return client.crosshairTarget.getType();
     }
 
     private double getTpsDropConfidence() {

--- a/src/main/resources/assets/nozh/lang/en_us.json
+++ b/src/main/resources/assets/nozh/lang/en_us.json
@@ -47,5 +47,12 @@
     "nozh.config.confirm.message": "This will reset ALL configuration to defaults. Continue?",
     "nozh.config.confirm.yes": "Yes, Reset",
     "nozh.config.confirm.no": "Cancel",
-    "nozh.config.done": "Done"
+    "nozh.config.done": "Done",
+    "nozh.scenario.standard": "Standard",
+    "nozh.scenario.combat": "Combat",
+    "nozh.scenario.building": "Building",
+    "nozh.scenario.mining": "Mining",
+    "nozh.scenario.afk": "AFK",
+    "nozh.scenario.menu": "Menu",
+    "nozh.scenario.loading": "Loading"
 }

--- a/src/main/resources/assets/nozh/lang/es_ar.json
+++ b/src/main/resources/assets/nozh/lang/es_ar.json
@@ -47,5 +47,12 @@
     "nozh.config.confirm.message": "Esto restablecerá TODA la configuración a valores predeterminados. ¿Continuar?",
     "nozh.config.confirm.yes": "Sí, Restablecer",
     "nozh.config.confirm.no": "Cancelar",
-    "nozh.config.done": "Listo"
+    "nozh.config.done": "Listo",
+    "nozh.scenario.standard": "Estándar",
+    "nozh.scenario.combat": "Combate",
+    "nozh.scenario.building": "Construcción",
+    "nozh.scenario.mining": "Minería",
+    "nozh.scenario.afk": "AFK",
+    "nozh.scenario.menu": "Menú",
+    "nozh.scenario.loading": "Cargando"
 }

--- a/src/main/resources/assets/nozh/lang/es_cl.json
+++ b/src/main/resources/assets/nozh/lang/es_cl.json
@@ -47,5 +47,12 @@
     "nozh.config.confirm.message": "Esto restablecerá TODA la configuración a valores predeterminados. ¿Continuar?",
     "nozh.config.confirm.yes": "Sí, Restablecer",
     "nozh.config.confirm.no": "Cancelar",
-    "nozh.config.done": "Listo"
+    "nozh.config.done": "Listo",
+    "nozh.scenario.standard": "Estándar",
+    "nozh.scenario.combat": "Combate",
+    "nozh.scenario.building": "Construcción",
+    "nozh.scenario.mining": "Minería",
+    "nozh.scenario.afk": "AFK",
+    "nozh.scenario.menu": "Menú",
+    "nozh.scenario.loading": "Cargando"
 }

--- a/src/main/resources/assets/nozh/lang/es_es.json
+++ b/src/main/resources/assets/nozh/lang/es_es.json
@@ -45,7 +45,14 @@
   "nozh.config.reset_safemode.tooltip": "Salir del modo seguro y reanudar operación normal. Úsalo si el mod detectó falsos positivos de bloqueo.",
   "nozh.config.confirm.title": "Confirmar Restablecimiento",
   "nozh.config.confirm.message": "Esto restablecerá TODA la configuración a valores predeterminados. ¿Continuar?",
-  "nozh.config.confirm.yes": "Sí, Restablecer",
-  "nozh.config.confirm.no": "Cancelar",
-  "nozh.config.done": "Listo"
+    "nozh.config.confirm.yes": "Sí, Restablecer",
+    "nozh.config.confirm.no": "Cancelar",
+    "nozh.config.done": "Listo",
+    "nozh.scenario.standard": "Estándar",
+    "nozh.scenario.combat": "Combate",
+    "nozh.scenario.building": "Construcción",
+    "nozh.scenario.mining": "Minería",
+    "nozh.scenario.afk": "AFK",
+    "nozh.scenario.menu": "Menú",
+    "nozh.scenario.loading": "Cargando"
 }

--- a/src/main/resources/assets/nozh/lang/es_mx.json
+++ b/src/main/resources/assets/nozh/lang/es_mx.json
@@ -47,5 +47,12 @@
     "nozh.config.confirm.message": "Esto restablecerá TODA la configuración a valores predeterminados. ¿Continuar?",
     "nozh.config.confirm.yes": "Sí, Restablecer",
     "nozh.config.confirm.no": "Cancelar",
-    "nozh.config.done": "Listo"
+    "nozh.config.done": "Listo",
+    "nozh.scenario.standard": "Estándar",
+    "nozh.scenario.combat": "Combate",
+    "nozh.scenario.building": "Construcción",
+    "nozh.scenario.mining": "Minería",
+    "nozh.scenario.afk": "AFK",
+    "nozh.scenario.menu": "Menú",
+    "nozh.scenario.loading": "Cargando"
 }

--- a/src/main/resources/assets/nozh/lang/es_uy.json
+++ b/src/main/resources/assets/nozh/lang/es_uy.json
@@ -47,5 +47,12 @@
     "nozh.config.confirm.message": "Esto restablecerá TODA la configuración a valores predeterminados. ¿Continuar?",
     "nozh.config.confirm.yes": "Sí, Restablecer",
     "nozh.config.confirm.no": "Cancelar",
-    "nozh.config.done": "Listo"
+    "nozh.config.done": "Listo",
+    "nozh.scenario.standard": "Estándar",
+    "nozh.scenario.combat": "Combate",
+    "nozh.scenario.building": "Construcción",
+    "nozh.scenario.mining": "Minería",
+    "nozh.scenario.afk": "AFK",
+    "nozh.scenario.menu": "Menú",
+    "nozh.scenario.loading": "Cargando"
 }


### PR DESCRIPTION
### Motivation
- Ensure the `ScenarioDetector` runs on every tick so the runtime `Scenario` stays up-to-date even when the governor loop is throttled. 
- Improve scenario classification by adding more gameplay signals (movement, combat interactions, block breaking, building) to better inform decisions. 
- Surface the detector confidence to the HUD so the UI can show both the detected `Scenario` and how confident the system is. 

### Description
- Run detection in `GovernorRunner.onTick()` and update runtime state immediately by calling `scenarioDetector.detect()` earlier in the tick path. 
- Extend `FabricScenarioDetector` with additional signals: crosshair target, hand swinging, block breaking, sprinting, finer movement deltas, and adjusted heuristics for combat/mining/building confidences. 
- Add `translationKey()` to `Scenario`, add `scenarioKey` and `scenarioConfidence` to `HudViewModel` and populate them in `HudViewModelBuilder`, and update `HudViewModel.EMPTY` defaults. 
- Add localized labels for all scenarios into the English and Spanish language files. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958ab1b4e4c832db063710e885574ad)