### PR TITLE
Record pre-action perf snapshots and rollback based on P95 evaluation

### DIFF
--- a/src/main/java/dev/nozh/client/NozhModClient.java
+++ b/src/main/java/dev/nozh/client/NozhModClient.java
@@ -90,7 +90,8 @@ public class NozhModClient implements ClientModInitializer {
                 capabilityExecutor,
                 logger,
                 sessionLearning,
-                () -> perfManager != null ? perfManager.getSnapshot() : dev.nozh.api.PerfSnapshot.empty());
+                () -> perfManager != null ? perfManager.getSnapshot() : dev.nozh.api.PerfSnapshot.empty(),
+                successTracker);
 
         // Create ScenarioDetector (Fabric implementation)
         dev.nozh.core.context.ScenarioDetector scenarioDetector = new dev.nozh.fabric.context.FabricScenarioDetector();

--- a/src/main/java/dev/nozh/core/bus/Command.java
+++ b/src/main/java/dev/nozh/core/bus/Command.java
@@ -1,5 +1,6 @@
 package dev.nozh.core.bus;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -24,6 +25,13 @@ public sealed interface Command {
     CommandType type();
 
     /**
+     * Optional inverse command for rollback purposes.
+     */
+    default Optional<Command> inverse(Optional<CapabilityValue> previousValue) {
+        return Optional.empty();
+    }
+
+    /**
      * Apply a capability value.
      */
     record ApplyCapability(
@@ -37,6 +45,14 @@ public sealed interface Command {
         @Override
         public CommandType type() {
             return CommandType.APPLY;
+        }
+
+        @Override
+        public Optional<Command> inverse(Optional<CapabilityValue> previousValue) {
+            if (previousValue.isPresent()) {
+                return Optional.of(new Command.ApplyCapability(capability, previousValue.get()));
+            }
+            return Optional.of(new Command.ResetCapability(capability));
         }
     }
 

--- a/src/main/java/dev/nozh/core/bus/StandardActionProcessor.java
+++ b/src/main/java/dev/nozh/core/bus/StandardActionProcessor.java
@@ -3,6 +3,7 @@ package dev.nozh.core.bus;
 import dev.nozh.api.PerfSnapshot;
 import dev.nozh.core.NozhLogger;
 import dev.nozh.core.intelligence.SessionLearning;
+import dev.nozh.core.matrix.ActionSuccessTracker;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -35,9 +36,23 @@ public final class StandardActionProcessor implements ActionProcessor {
     private final NozhLogger logger;
     private final SessionLearning sessionLearning;
     private final Supplier<PerfSnapshot> perfSnapshotSupplier;
+    private final ActionSuccessTracker successTracker;
 
     public StandardActionProcessor(CapabilityExecutor executor, NozhLogger logger) {
-        this(executor, logger, null, PerfSnapshot::empty);
+        this(executor, logger, null, PerfSnapshot::empty, null);
+    }
+
+    public StandardActionProcessor(
+            CapabilityExecutor executor,
+            NozhLogger logger,
+            SessionLearning sessionLearning,
+            Supplier<PerfSnapshot> perfSnapshotSupplier,
+            ActionSuccessTracker successTracker) {
+        this.executor = executor;
+        this.logger = logger;
+        this.sessionLearning = sessionLearning;
+        this.perfSnapshotSupplier = perfSnapshotSupplier != null ? perfSnapshotSupplier : PerfSnapshot::empty;
+        this.successTracker = successTracker;
     }
 
     public StandardActionProcessor(
@@ -45,10 +60,7 @@ public final class StandardActionProcessor implements ActionProcessor {
             NozhLogger logger,
             SessionLearning sessionLearning,
             Supplier<PerfSnapshot> perfSnapshotSupplier) {
-        this.executor = executor;
-        this.logger = logger;
-        this.sessionLearning = sessionLearning;
-        this.perfSnapshotSupplier = perfSnapshotSupplier != null ? perfSnapshotSupplier : PerfSnapshot::empty;
+        this(executor, logger, sessionLearning, perfSnapshotSupplier, null);
     }
 
     @Override
@@ -85,6 +97,9 @@ public final class StandardActionProcessor implements ActionProcessor {
         CapabilityId capability = cmd.capability();
         CapabilityValue value = cmd.value();
         PerfSnapshot beforeSnapshot = perfSnapshotSupplier.get();
+        if (successTracker != null) {
+            successTracker.recordPreActionSnapshot(capability, beforeSnapshot);
+        }
 
         // Store old value for potential rollback
         Optional<CapabilityValue> oldValue = Optional.empty();

--- a/src/main/java/dev/nozh/core/governor/GovernorRunner.java
+++ b/src/main/java/dev/nozh/core/governor/GovernorRunner.java
@@ -35,6 +35,7 @@ public final class GovernorRunner {
     private final StateStore stateStore;
     private final ProviderRegistry providerRegistry;
     private final SessionLearning sessionLearning;
+    private final ActionSuccessTracker successTracker;
 
     // Intelligent components
     private final dev.nozh.core.governor.PredictiveAnalyzer predictiveAnalyzer;
@@ -66,6 +67,7 @@ public final class GovernorRunner {
         this.logger = logger;
         this.providerRegistry = registry;
         this.sessionLearning = sessionLearning;
+        this.successTracker = successTracker;
         this.scenarioDetector = scenarioDetector;
         this.conflictDetector = new ModConflictDetector();
 
@@ -152,6 +154,7 @@ public final class GovernorRunner {
         }
 
         ActionCandidate decision = decisionOpt.get();
+        successTracker.recordDecision(decision);
         String steward = conflictDetector.getSteward(decision.capabilityId());
         // REMOVED: withDecision() tracking no longer available
         String actionSummary = formatActionSummary(decision);
@@ -169,16 +172,17 @@ public final class GovernorRunner {
         if (decision.targetValue() != null) {
             Optional<dev.nozh.core.bus.CapabilityValue> previousValue = providerRegistry.get(decision.capabilityId())
                     .flatMap(provider -> provider.getCurrentValueSafe());
+            Command cmd = new Command.ApplyCapability(
+                    decision.capabilityId(),
+                    decision.targetValue());
             PendingAction pending = new PendingAction(
                     now,
                     decision.capabilityId(),
+                    cmd,
                     previousValue,
                     decision.targetValue(),
                     state.avgFrametimeMs(),
                     state.p95FrametimeMs());
-            Command cmd = new Command.ApplyCapability(
-                    decision.capabilityId(),
-                    decision.targetValue());
 
             actionBus.dispatch(cmd, report -> {
                 if (report.succeeded()) {
@@ -266,38 +270,44 @@ public final class GovernorRunner {
 
     private void evaluatePendingAction(RuntimeState state, PendingAction pending, NozhConfig config) {
         double avg = state.avgFrametimeMs();
-        // double p95 = state.p95FrametimeMs(); // Not strictly using p95 decision yet,
-        // focusing on avg latency gain
+        double p95 = state.p95FrametimeMs();
+        double preP95 = resolvePreP95(pending);
+        double preAvg = pending.baselineAvgMs();
+        double epsilonP95 = config.improvementEpsilonP95Ms;
+
+        boolean p95Valid = isValidPerfValue(preP95) && isValidPerfValue(p95);
+        double baselineMetric = p95Valid ? preP95 : preAvg;
+        double currentMetric = p95Valid ? p95 : avg;
+        double epsilon = p95Valid ? epsilonP95 : config.improvementEpsilonAvgMs;
 
         // Strict Evaluation:
-        // 1. Worsened: Avg increased significantly ( > baseline + epsilon)
-        // 2. Ineffective: Avg didn't decrease enough ( > baseline - epsilon)
-        // Goal: avg < baseline - epsilon
+        // 1. Worsened: P95 increased significantly ( > baseline + epsilon)
+        // 2. Ineffective: P95 didn't decrease enough ( > baseline - epsilon)
+        // Goal: P95 < baseline - epsilon
 
-        boolean worsened = avg > pending.baselineAvgMs() + config.improvementEpsilonAvgMs;
-        boolean ineffective = avg > pending.baselineAvgMs() - config.improvementEpsilonAvgMs;
+        boolean worsened = currentMetric > baselineMetric + epsilon;
+        boolean ineffective = currentMetric > baselineMetric - epsilon;
 
         if (worsened || ineffective) {
             if (config.rollbackEnabled) {
-                Command rollback = pending.previousValue()
-                        .<Command>map(v -> new Command.ApplyCapability(pending.capability(), v))
-                        .orElseGet(() -> new Command.ResetCapability(pending.capability()));
-
-                actionBus.dispatch(rollback, r -> {
-                    if (r.succeeded()) {
-                        logger.info("Rollback succeeded (Action was " + (worsened ? "harmful" : "ineffective") + ")");
-                    } else {
-                        logger.warn("Rollback failed");
-                    }
-                });
+                pending.actionCommand()
+                        .inverse(pending.previousValue())
+                        .ifPresentOrElse(rollback -> actionBus.dispatch(rollback, r -> {
+                            if (r.succeeded()) {
+                                logger.info(
+                                        "Rollback succeeded (Action was " + (worsened ? "harmful" : "ineffective") + ")");
+                            } else {
+                                logger.warn("Rollback failed");
+                            }
+                        }), () -> logger.warn("No inverse action available, rollback skipped."));
             } else {
                 logger.info("Rollback disabled in config, keeping ineffective action.");
             }
 
             sessionLearning.recordFailure(pending.capability());
         } else {
-            // Success: avg <= baseline - epsilon
-            double gain = Math.max(0, pending.baselineAvgMs() - avg);
+            // Success: metric <= baseline - epsilon
+            double gain = Math.max(0, baselineMetric - currentMetric);
             sessionLearning.recordSuccess(pending.capability(), gain);
         }
         // Clear pending action
@@ -306,6 +316,20 @@ public final class GovernorRunner {
         } catch (Exception e) {
             logger.warn("Failed to clear pending action");
         }
+        successTracker.clearDecisionSnapshot(pending.capability());
+    }
+
+    private double resolvePreP95(PendingAction pending) {
+        return successTracker.getDecisionSnapshot(pending.capability())
+                .map(snapshot -> snapshot.preSnapshot())
+                .filter(snapshot -> snapshot != null)
+                .map(snapshot -> snapshot.p95FrametimeMs())
+                .filter(this::isValidPerfValue)
+                .orElse(pending.baselineP95Ms());
+    }
+
+    private boolean isValidPerfValue(double value) {
+        return Double.isFinite(value) && value > 0;
     }
 
     private String formatActionSummary(ActionCandidate decision) {

--- a/src/main/java/dev/nozh/core/matrix/ActionSuccessTracker.java
+++ b/src/main/java/dev/nozh/core/matrix/ActionSuccessTracker.java
@@ -1,8 +1,10 @@
 package dev.nozh.core.matrix;
 
+import dev.nozh.api.PerfSnapshot;
 import dev.nozh.core.bus.CapabilityId;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -16,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class ActionSuccessTracker {
 
     private final Map<CapabilityId, SuccessRecord> records = new ConcurrentHashMap<>();
+    private final Map<CapabilityId, DecisionPerfSnapshot> decisionSnapshots = new ConcurrentHashMap<>();
     private String currentEnvironmentHash;
 
     public ActionSuccessTracker(String initialEnvironmentHash) {
@@ -114,6 +117,47 @@ public final class ActionSuccessTracker {
     }
 
     /**
+     * Record a decision for later performance evaluation.
+     */
+    public void recordDecision(ActionCandidate decision) {
+        if (decision == null) {
+            return;
+        }
+        decisionSnapshots.put(
+                decision.capabilityId(),
+                new DecisionPerfSnapshot(decision, PerfSnapshot.empty()));
+    }
+
+    /**
+     * Record performance snapshot before applying an action.
+     */
+    public void recordPreActionSnapshot(CapabilityId id, PerfSnapshot snapshot) {
+        if (id == null || snapshot == null) {
+            return;
+        }
+        decisionSnapshots.compute(id, (key, existing) -> {
+            if (existing == null) {
+                return new DecisionPerfSnapshot(null, snapshot);
+            }
+            return new DecisionPerfSnapshot(existing.decision(), snapshot);
+        });
+    }
+
+    /**
+     * Get the most recent decision snapshot for a capability.
+     */
+    public Optional<DecisionPerfSnapshot> getDecisionSnapshot(CapabilityId id) {
+        return Optional.ofNullable(decisionSnapshots.get(id));
+    }
+
+    /**
+     * Clear decision snapshot after evaluation.
+     */
+    public void clearDecisionSnapshot(CapabilityId id) {
+        decisionSnapshots.remove(id);
+    }
+
+    /**
      * Internal success record.
      */
     private record SuccessRecord(
@@ -122,5 +166,10 @@ public final class ActionSuccessTracker {
             long lastSuccessMillis,
             long lastFailureMillis,
             String environmentHash) {
+    }
+
+    public record DecisionPerfSnapshot(
+            ActionCandidate decision,
+            PerfSnapshot preSnapshot) {
     }
 }

--- a/src/main/java/dev/nozh/core/state/PendingAction.java
+++ b/src/main/java/dev/nozh/core/state/PendingAction.java
@@ -2,6 +2,7 @@ package dev.nozh.core.state;
 
 import dev.nozh.core.bus.CapabilityId;
 import dev.nozh.core.bus.CapabilityValue;
+import dev.nozh.core.bus.Command;
 
 import java.util.Optional;
 
@@ -13,6 +14,7 @@ import java.util.Optional;
 public record PendingAction(
         long timestampMillis,
         CapabilityId capability,
+        Command actionCommand,
         Optional<CapabilityValue> previousValue,
         CapabilityValue newValue,
         double baselineAvgMs,

--- a/src/test/java/dev/nozh/core/state/StateInvariantValidatorTest.java
+++ b/src/test/java/dev/nozh/core/state/StateInvariantValidatorTest.java
@@ -18,6 +18,7 @@ class StateInvariantValidatorTest {
                 return new PendingAction(
                                 System.currentTimeMillis(),
                                 null,
+                                new dev.nozh.core.bus.Command.ResetCapability(null),
                                 Optional.empty(),
                                 null,
                                 16.0,


### PR DESCRIPTION
### Motivation

- Capture performance state immediately before applying an action so post-hoc evaluation can compare pre/post effects.
- Persist the pre-action snapshot together with the governor `Decision` so a delayed evaluation task can use P95 instead of only avg.
- If P95 does not improve, enqueue a rollback using the action's inverse where available to avoid harmful or ineffective changes.
- Record outcome as success/failure in session learning to improve future recommendations.

### Description

- Added an `inverse(Optional<CapabilityValue>)` hook to `Command` and implemented it for `Command.ApplyCapability` to produce a rollback `Command` or `ResetCapability` when previous value is available.
- Extended `PendingAction` to include the applied `actionCommand` so the governor can derive an inverse command later, and updated `NozhModClient` wiring to pass `ActionSuccessTracker` into `StandardActionProcessor`.
- Implemented decision/perf snapshot tracking in `ActionSuccessTracker` with `recordDecision`, `recordPreActionSnapshot`, `getDecisionSnapshot`, and `clearDecisionSnapshot`, and `StandardActionProcessor` now records a pre-action `PerfSnapshot` before executing an `ApplyCapability`.
- Modified `GovernorRunner` to record decisions, resolve pre-action P95 (fallback to avg if needed), evaluate pending actions by comparing P95 pre/post with configured epsilons, dispatch rollback via `pending.actionCommand().inverse(...)` when ineffective, clear stored decision snapshots, and compute gain passed to `SessionLearning`.

### Testing

- Updated `StateInvariantValidatorTest` to construct a `PendingAction` with a dummy `Command` to match the new constructor that stores the `actionCommand`.
- No automated test run was executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958aaedff00832d8967ec89324d3c07)