### PR TITLE
Add manual-assist suggestions and fix GovernorRunner call sites

### DIFF
--- a/src/main/java/dev/nozh/core/governor/GovernorRunner.java
+++ b/src/main/java/dev/nozh/core/governor/GovernorRunner.java
@@ -115,7 +115,7 @@ public final class GovernorRunner {
             return;
         }
 
-        if (state.pendingSuggestion().isPresent()) {
+        if (state.suggestedAction().isPresent()) {
             logger.debug("Pending suggestion awaiting confirmation");
             return;
         }
@@ -323,7 +323,7 @@ public final class GovernorRunner {
 
         if (worsened || ineffective) {
             if (config.rollbackEnabled) {
-                pending.actionCommand()
+                pending.command()
                         .inverse(pending.previousValue())
                         .ifPresentOrElse(rollback -> actionBus.dispatch(rollback, r -> {
                             if (r.succeeded()) {


### PR DESCRIPTION
### Motivation
- Enable a manual-assist workflow where the governor can stage capability changes that require explicit user confirmation rather than auto-applying.
- Persist suggestion metadata in runtime state so staged suggestions can be confirmed, executed, and evaluated for rollback.
- Keep state compatibility by providing explicit migrations for the new state field/version.
- Ensure config changes propagate to runtime via a listener API so UI/commands can update `StateStore` consistently.

### Description
- Added `suggestedAction` (an `Optional<PendingAction>`) to `RuntimeState` with `withSuggestedAction` and `withSuggestedActionCleared`, bumped state version to `4`, and added corresponding migrators in the `StateMigrationRegistry`.
- Updated `GovernorRunner` to queue suggestions when in `MANUAL_ASSIST` mode, skip auto-dispatch while a suggestion is pending, and use `PendingAction`'s `command()` accessor when resolving rollback inverses.
- Implemented `/nozh apply` in `NozhCommands` to dispatch `Command.ApplyCapability`, record the governor action via `withGovernorAction(...)`, and clear the staged suggestion with `withSuggestedActionCleared()`.
- Continued config/UX wiring by adding `ConfigListener` support to `ConfigManager`, `saveAndNotify()` helpers, and registering `StateStore` as a config listener so UI/presets use `ConfigManager.saveAndNotify()`.

### Testing
- CI `./gradlew build` failed due to dependency fetch issues from Maven Central (HTTP 403) and compilation errors from mismatched accessors, so the automated build did not complete successfully.
- No automated unit or integration tests were executed in CI for these changes due to the build failure.
- Local iterative edits and compilation-focused fixes were performed to update call sites and keep APIs consistent, and changes were committed locally without an automated verification run.
- After correcting `GovernorRunner` call sites the source was updated and committed locally, but no CI or local automated tests were run to validate the full integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958bee243c8832d9d3fac995a526cfa)