### PR TITLE
Mark legacy state APIs as deprecated-for-removal and update tests

### DIFF
--- a/src/main/java/dev/nozh/core/state/PendingAction.java
+++ b/src/main/java/dev/nozh/core/state/PendingAction.java
@@ -20,9 +20,10 @@ public record PendingAction(
         double baselineAvgMs,
         double baselineP95Ms) {
     /**
-     * Compatibility constructor for older call sites that did not pass the command.
+     * Legacy compatibility constructor for older call sites that did not pass the command.
+     * Scheduled for removal in a cleanup pass.
      */
-    @Deprecated
+    @Deprecated(since = "1.0", forRemoval = true)
     public PendingAction(
             long timestampMillis,
             CapabilityId capability,
@@ -41,9 +42,10 @@ public record PendingAction(
     }
 
     /**
-     * Compatibility alias for older call sites.
+     * Legacy compatibility alias for older call sites.
+     * Scheduled for removal in a cleanup pass.
      */
-    @Deprecated
+    @Deprecated(since = "1.0", forRemoval = true)
     public Command actionCommand() {
         return command;
     }

--- a/src/main/java/dev/nozh/core/state/RuntimeState.java
+++ b/src/main/java/dev/nozh/core/state/RuntimeState.java
@@ -207,9 +207,10 @@ public record RuntimeState(
     }
 
     /**
-     * Compatibility alias for older callers.
+     * Legacy compatibility alias for older callers.
+     * Scheduled for removal in a cleanup pass.
      */
-    @Deprecated
+    @Deprecated(since = "1.0", forRemoval = true)
     public Optional<PendingAction> pendingSuggestion() {
         return suggestedAction;
     }

--- a/src/test/java/dev/nozh/core/state/StateInvariantValidatorTest.java
+++ b/src/test/java/dev/nozh/core/state/StateInvariantValidatorTest.java
@@ -42,7 +42,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
-                                state.pendingSuggestion(),
+                                state.suggestedAction(),
                                 state.pendingActionsCount(),
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -80,7 +80,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
-                                state.pendingSuggestion(),
+                                state.suggestedAction(),
                                 state.pendingActionsCount(),
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -119,7 +119,7 @@ class StateInvariantValidatorTest {
                                 "NONE", // benchmarkValidity
                                 System.currentTimeMillis(),
                                 base.pendingAction(),
-                                base.pendingSuggestion(),
+                                base.suggestedAction(),
                                 base.pendingActionsCount(),
                                 base.executionHistorySize(),
                                 base.lastSnapshotHistorySize(),
@@ -157,7 +157,7 @@ class StateInvariantValidatorTest {
                                 "NONE", // benchmarkValidity
                                 System.currentTimeMillis(),
                                 state.pendingAction(),
-                                state.pendingSuggestion(),
+                                state.suggestedAction(),
                                 state.pendingActionsCount(),
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -192,7 +192,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
-                                state.pendingSuggestion(),
+                                state.suggestedAction(),
                                 3, // pendingActionsCount > 0
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -230,7 +230,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
-                                state.pendingSuggestion(),
+                                state.suggestedAction(),
                                 3, // pendingActionsCount > 0
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),
@@ -267,7 +267,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
-                                state.pendingSuggestion(),
+                                state.suggestedAction(),
                                 state.pendingActionsCount(),
                                 5, // executionHistorySize = 5
                                 10, // lastSnapshotHistorySize = 10 (VIOLATION: decreased)
@@ -307,7 +307,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 state.benchmarkStartTimestamp(),
                                 state.pendingAction(),
-                                state.pendingSuggestion(),
+                                state.suggestedAction(),
                                 state.pendingActionsCount(),
                                 15, // executionHistorySize = 15
                                 10, // lastSnapshotHistorySize = 10 (OK: increased)
@@ -345,7 +345,7 @@ class StateInvariantValidatorTest {
                                 state.benchmarkValidity(),
                                 System.currentTimeMillis(),
                                 state.pendingAction(),
-                                state.pendingSuggestion(),
+                                state.suggestedAction(),
                                 5, // pendingActionsCount > 0 (VIOLATION 3)
                                 state.executionHistorySize(),
                                 state.lastSnapshotHistorySize(),

--- a/src/test/java/dev/nozh/core/state/TestStates.java
+++ b/src/test/java/dev/nozh/core/state/TestStates.java
@@ -19,7 +19,7 @@ public final class TestStates {
                 state.benchmarkValidity(),
                 state.benchmarkStartTimestamp(),
                 state.pendingAction(),
-                state.pendingSuggestion(),
+                state.suggestedAction(),
                 state.pendingActionsCount(),
                 state.executionHistorySize(),
                 state.lastSnapshotHistorySize(),


### PR DESCRIPTION
### Motivation
- Mark a few older RuntimeState/PendingAction compatibility APIs as legacy to make future cleanup explicit and avoid silent technical debt.
- Ensure test code uses the current `suggestedAction()` accessor rather than legacy aliases to keep tests aligned with the public API.
- Preserve backward compatibility for a short transition period by keeping legacy methods present but annotated for removal.

### Description
- Annotated the `PendingAction` compatibility constructor and `PendingAction.actionCommand()` alias with `@Deprecated(since = "1.0", forRemoval = true)` and added explanatory comments.  
- Annotated `RuntimeState.pendingSuggestion()` with `@Deprecated(since = "1.0", forRemoval = true)` and added a legacy/cleanup note.  
- Updated tests and helpers to call the current accessor `suggestedAction()` instead of the legacy `pendingSuggestion()` in `StateInvariantValidatorTest` and `TestStates`.  

### Testing
- No automated test suite was executed as part of this change.  
- Updated unit test sources compile-time references to the new accessor and were adjusted accordingly (no runtime verification performed).  
- Static searches (`rg`) were used to find usages of the legacy API before changes.  
- All changes committed locally; no CI results are available in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f85b091c832db05e1d625ea7d4b1)