### PR TITLE
Align manual suggestion apply flow

### DIFF
--- a/src/main/java/dev/nozh/client/NozhCommands.java
+++ b/src/main/java/dev/nozh/client/NozhCommands.java
@@ -7,7 +7,6 @@ import dev.nozh.core.config.NozhConfig;
 import dev.nozh.core.state.PendingAction;
 import dev.nozh.core.state.RuntimeState;
 import dev.nozh.core.state.StateStore;
-import dev.nozh.core.bus.Command;
 import dev.nozh.core.safety.CrashLoopGuard;
 import dev.nozh.core.safety.StateManager;
 import dev.nozh.core.safety.NozhState;
@@ -296,39 +295,7 @@ public final class NozhCommands {
     }
 
     public static void runApply(FabricClientCommandSource source) {
-        runApplySuggestion(source);
-    }
-
-    private static void runApplySuggestion(FabricClientCommandSource source) {
-        var actionBus = NozhModClient.getActionBus();
-        if (actionBus == null) {
-            source.sendFeedback(Text.literal("NOZH action bus unavailable"));
-            return;
-        }
-
-        RuntimeState state = StateStore.getInstance().snapshotSafe();
-        if (state.suggestedAction().isEmpty()) {
-            source.sendFeedback(Text.literal("No pending suggestion to apply"));
-            return;
-        }
-
-        PendingAction pending = state.suggestedAction().get();
-        Command command = pending.command();
-        long now = System.currentTimeMillis();
-
-        actionBus.dispatch(command, report -> {
-            if (report.succeeded()) {
-                source.sendFeedback(Text.literal("Applied suggested change"));
-            } else {
-                String reason = report.error().orElse("unknown");
-                source.sendFeedback(Text.literal("Failed to apply suggestion: " + reason));
-                StateStore.getInstance().update(RuntimeState::withPendingActionCleared);
-            }
-        });
-
-        StateStore.getInstance().update(currentState -> currentState
-                .withGovernorAction(now, pending)
-                .withSuggestedActionCleared());
+        NozhModClient.applySuggestedAction(source::sendFeedback, source::sendError);
     }
 
     private static void runClearSuggestion(FabricClientCommandSource source) {

--- a/src/main/java/dev/nozh/client/NozhModClient.java
+++ b/src/main/java/dev/nozh/client/NozhModClient.java
@@ -33,6 +33,8 @@ import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
 import org.lwjgl.glfw.GLFW;
 
+import java.util.function.Consumer;
+
 /**
  * NOZH Client-side initializer - FULL INTEGRATION.
  * 
@@ -265,15 +267,25 @@ public class NozhModClient implements ClientModInitializer {
         if (client == null) {
             return;
         }
+        applySuggestedAction(
+                message -> notifyClient(client, message),
+                message -> notifyClient(client, message));
+    }
+
+    public static void applySuggestedAction(Consumer<Text> feedback, Consumer<Text> errorFeedback) {
+        if (feedback == null || errorFeedback == null) {
+            return;
+        }
         var bus = actionBus;
         if (bus == null) {
-            notifyClient(client, Text.literal("Action bus unavailable"));
+            errorFeedback.accept(Text.literal("Action bus unavailable"));
+            NozhConstants.LOGGER.warn("Manual apply failed: action bus unavailable");
             return;
         }
 
         RuntimeState state = stateStore.snapshotSafe();
         if (state.suggestedAction().isEmpty()) {
-            notifyClient(client, Text.literal("No pending suggestion"));
+            feedback.accept(Text.literal("No pending suggestion"));
             return;
         }
 
@@ -281,19 +293,22 @@ public class NozhModClient implements ClientModInitializer {
         Command command = pending.command();
         long now = System.currentTimeMillis();
 
-        bus.dispatch(command, report -> {
+        bus.dispatchUserCommand(command, report -> {
             if (report.succeeded()) {
-                notifyClient(client, Text.literal("Applied suggested change"));
+                feedback.accept(Text.literal("Applied suggested change"));
+                NozhConstants.LOGGER.info("Manual suggestion applied: " + pending.capability().name());
             } else {
                 String reason = report.error().orElse("unknown");
-                notifyClient(client, Text.literal("Failed to apply: " + reason));
-                stateStore.update(RuntimeState::withPendingActionCleared);
+                errorFeedback.accept(Text.literal("Suggestion rejected: " + reason));
+                NozhConstants.LOGGER.warn(
+                        "Manual suggestion rejected for " + pending.capability().name() + ": " + reason);
+                stateStore.update(currentState -> currentState
+                        .withPendingActionCleared()
+                        .withSuggestedAction(pending));
             }
         });
 
-        stateStore.update(currentState -> currentState
-                .withGovernorAction(now, pending)
-                .withSuggestedActionCleared());
+        stateStore.update(currentState -> currentState.withAppliedSuggestion(now, pending));
     }
 
     private static void notifyClient(MinecraftClient client, Text message) {


### PR DESCRIPTION
### Motivation
- Route manual suggestion application through a single client flow so `NozhCommands` and `NozhModClient` use the same execution path.
- Ensure manual confirmations bypass auto-tuning gating and are explicitly logged for auditability.
- Make `suggestedAction` and `pendingAction` transitions explicit in `RuntimeState` when a user applies or rejects a suggestion.

### Description
- Route the `/nozh apply` command to `NozhModClient.applySuggestedAction` instead of duplicating dispatch logic in `NozhCommands`.
- Add an overload `applySuggestedAction(Consumer<Text>, Consumer<Text>)` and use `ActionBus.dispatchUserCommand` to mark user-initiated dispatches.
- Update state on success via `RuntimeState.withAppliedSuggestion(now, pending)` and on rejection clear pending and restore the suggestion using `RuntimeState::withPendingActionCleared` and `withSuggestedAction`.
- Add targeted logging calls with `NozhConstants.LOGGER` and use provided `feedback`/`errorFeedback` consumers for in-client messages.

### Testing
- No automated unit or integration tests were executed for this change.
- Recommended automated check: run `./gradlew test` and a local client run to validate HUD/command behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f862d7a0832db213c91e1e0d9c5d)