### PR TITLE
Improve Gradle CI setup: switch action, verify wrapper, refresh deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,18 @@ jobs:
         distribution: 'temurin'
     
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v3
       with:
         cache-disabled: true
     
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+
+    - name: Verify Gradle wrapper download
+      run: ./gradlew --version
     
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --no-daemon --refresh-dependencies
     
     - name: Upload artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Motivation

- Ensure the Gradle wrapper and dependencies are reliably downloaded in CI to avoid cache-related pipeline breaks.
- Keep existing Maven repositories (Modrinth, Fabric, Terraformers) configured in `build.gradle` for dependency resolution.
- Use the current recommended Gradle setup action to align CI with upstream tooling.

### Description

- Replace `gradle/gradle-build-action@v2` with `gradle/actions/setup-gradle@v3` in `.github/workflows/build.yml`.
- Add a step to run `./gradlew --version` to verify the Gradle wrapper can be downloaded before building.
- Change the build step to run `./gradlew build --no-daemon --refresh-dependencies` to force a clean dependency resolution.

### Testing

- Ran `./gradlew build` initially which failed with a permission error (`exit code 126`) until `gradlew` was made executable.
- After making `gradlew` executable, ran `./gradlew build --no-daemon --refresh-dependencies` which failed because the Gradle distribution download was blocked by a proxy returning `HTTP/1.1 403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f85c7420832daf6a73902bc9029b)