### PR TITLE
Fix NozhCommands suggestion handlers

### DIFF
--- a/src/main/java/dev/nozh/client/NozhCommands.java
+++ b/src/main/java/dev/nozh/client/NozhCommands.java
@@ -4,7 +4,6 @@ import dev.nozh.NozhConstants;
 import dev.nozh.core.compat.CompatService;
 import dev.nozh.core.config.ConfigManager;
 import dev.nozh.core.config.NozhConfig;
-import dev.nozh.core.state.PendingAction;
 import dev.nozh.core.state.RuntimeState;
 import dev.nozh.core.state.StateStore;
 import dev.nozh.core.safety.CrashLoopGuard;
@@ -315,6 +314,7 @@ public final class NozhCommands {
         NozhModClient.applySuggestedAction(client);
     }
 
+    private static void runClearSuggestion(FabricClientCommandSource source) {
         RuntimeState state = StateStore.getInstance().snapshotSafe();
         if (state.suggestedAction().isEmpty()) {
             source.sendFeedback(Text.translatable("nozh.suggestion.clear.none"));
@@ -338,24 +338,5 @@ public final class NozhCommands {
         } catch (Exception e) {
             source.sendFeedback(Text.translatable("nozh.telemetry.export.failed", e.getMessage()));
         }
-    }
-
-        PendingAction pending = state.suggestedAction().get();
-        Command command = new Command.ApplyCapability(pending.capability(), pending.newValue());
-        long now = System.currentTimeMillis();
-
-        actionBus.dispatch(command, report -> {
-            if (report.succeeded()) {
-                source.sendFeedback(Text.literal("Applied suggested change"));
-            } else {
-                String reason = report.error().orElse("unknown");
-                source.sendFeedback(Text.literal("Failed to apply suggestion: " + reason));
-                StateStore.getInstance().update(RuntimeState::withPendingActionCleared);
-            }
-        });
-
-        StateStore.getInstance().update(currentState -> currentState
-                .withGovernorAction(now, pending)
-                .withSuggestedActionCleared());
     }
 }


### PR DESCRIPTION
### Motivation
- Resolve compilation errors in `NozhCommands.java` caused by stray suggestion-handling code that broke the class structure.
- Make suggestion-clear behavior explicit and reusable via a dedicated helper.
- Clean up unused imports introduced/left behind by earlier edits.

### Description
- Added a new helper `runClearSuggestion(FabricClientCommandSource)` that contains the suggestion-clear logic extracted from the stray block.
- Removed a stray suggestion-apply block that was located outside the class body and caused compile-time errors.
- Removed the unused `PendingAction` import and performed small structural/whitespace cleanup to restore valid Java syntax.

### Testing
- No automated tests were executed after this change.
- Prior CI runs failed during `:compileJava` with multiple syntax errors; this PR removes the offending code to allow compilation.
- Recommend running the project build (`./gradlew build`) in CI to validate compilation and run automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958fee9ee08832da7d065de78dfdaa1)