### PR TITLE
Blend session learning into confidence scoring; session-scoped persistence and robust outcome evaluation

### DIFF
--- a/src/main/java/dev/nozh/client/NozhModClient.java
+++ b/src/main/java/dev/nozh/client/NozhModClient.java
@@ -58,6 +58,7 @@ public class NozhModClient implements ClientModInitializer {
     private static KeyBinding toggleHudKey;
     private static KeyBinding applySuggestionKey;
     private static boolean safeModeNotified = false;
+    private static String lastSessionKey = null;
 
     private static int tickCounter = 0;
     private static final int TELEMETRY_UPDATE_INTERVAL = 20; // Every second (20 ticks)
@@ -224,6 +225,14 @@ public class NozhModClient implements ClientModInitializer {
             if (governorRunner != null) {
                 governorRunner.captureBaselineSettings();
             }
+            if (sessionLearning != null) {
+                String sessionKey = resolveSessionKey(client, handler);
+                if (lastSessionKey == null || !lastSessionKey.equals(sessionKey)) {
+                    sessionLearning.resetForSession(sessionKey);
+                    sessionLearning.save();
+                    lastSessionKey = sessionKey;
+                }
+            }
         });
 
         // === COMMANDS & SHUTDOWN ===
@@ -354,5 +363,22 @@ public class NozhModClient implements ClientModInitializer {
         if (client.inGameHud != null) {
             client.inGameHud.getChatHud().addMessage(title.copy().append(Text.literal(" ")).append(message));
         }
+    }
+
+    private static String resolveSessionKey(MinecraftClient client,
+            net.minecraft.client.network.ClientPlayNetworkHandler handler) {
+        if (client != null && client.isIntegratedServerRunning() && client.getServer() != null) {
+            try {
+                String levelName = client.getServer().getSaveProperties().getLevelName();
+                if (levelName != null && !levelName.isBlank()) {
+                    return "local:" + levelName;
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        if (handler != null && handler.getConnection() != null && handler.getConnection().getAddress() != null) {
+            return "remote:" + handler.getConnection().getAddress().toString();
+        }
+        return "unknown";
     }
 }

--- a/src/main/java/dev/nozh/core/governor/GovernorRunner.java
+++ b/src/main/java/dev/nozh/core/governor/GovernorRunner.java
@@ -29,6 +29,7 @@ import dev.nozh.core.monitoring.SystemMonitor;
 
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -427,24 +428,34 @@ public final class GovernorRunner {
             return;
         }
         PerfSnapshot currentSnapshot = perfSnapshotSupplier.get();
-        if (currentSnapshot == null
-                || pending.baselineSnapshot() == null
-                || !currentSnapshot.sufficientData()
-                || !pending.baselineSnapshot().sufficientData()) {
-            logger.debug("Skipping outcome evaluation (insufficient perf snapshot data)");
-            return;
+        if (currentSnapshot == null) {
+            currentSnapshot = PerfSnapshot.empty();
+        }
+        PerfSnapshot baselineSnapshot = pending.baselineSnapshot();
+        if (baselineSnapshot == null) {
+            baselineSnapshot = PerfSnapshot.empty();
+        }
+        boolean sufficientData = currentSnapshot != null
+                && baselineSnapshot != null
+                && currentSnapshot.sufficientData()
+                && baselineSnapshot.sufficientData();
+
+        ActionOutcome outcome = sufficientData
+                ? governor.evaluateOutcome(baselineSnapshot, currentSnapshot)
+                : evaluateOutcomeFallback(baselineSnapshot, currentSnapshot);
+        if (!sufficientData) {
+            logger.debug("Outcome evaluation fallback used (insufficient perf snapshot data)");
         }
 
-        ActionOutcome outcome = governor.evaluateOutcome(pending.baselineSnapshot(), currentSnapshot);
-        int observationWindowSeconds = resolveObservationWindowSeconds(currentSnapshot);
-        double p95Delta = currentSnapshot.p95FrametimeMs() - pending.baselineSnapshot().p95FrametimeMs();
-        int spikeDelta = currentSnapshot.spikeCount() - pending.baselineSnapshot().spikeCount();
+        int observationWindowSeconds = resolveObservationWindowSeconds(currentSnapshot != null ? currentSnapshot : baselineSnapshot);
+        double p95Delta = resolveDelta(currentSnapshot, baselineSnapshot, PerfSnapshot::p95FrametimeMs);
+        int spikeDelta = resolveSpikeDelta(currentSnapshot, baselineSnapshot);
         if (spikeDelta > 0) {
             outcome = ActionOutcome.NEGATIVE;
         }
 
         boolean rollbackApplied = false;
-        if (outcome != ActionOutcome.POSITIVE) {
+        if (outcome != ActionOutcome.POSITIVE && sufficientData) {
             if (config.rollbackEnabled) {
                 Long lastRollback = rollbackCooldowns.get(pending.capability());
                 if (lastRollback != null && nowMillis() - lastRollback < config.rollbackCooldownMillis) {
@@ -460,8 +471,8 @@ public final class GovernorRunner {
             sessionLearning.recordFailure(pending.capability(), pending.scenario());
             successTracker.recordFailure(pending.capability());
         } else if (outcome == ActionOutcome.POSITIVE) {
-            double gainAvg = Math.max(0, pending.baselineAvgMs() - currentSnapshot.avgFrametimeMs());
-            double gainP95 = Math.max(0, pending.baselineP95Ms() - currentSnapshot.p95FrametimeMs());
+            double gainAvg = resolveGain(pending.baselineAvgMs(), currentSnapshot != null ? currentSnapshot.avgFrametimeMs() : Double.NaN);
+            double gainP95 = resolveGain(pending.baselineP95Ms(), currentSnapshot != null ? currentSnapshot.p95FrametimeMs() : Double.NaN);
             sessionLearning.recordSuccess(pending.capability(), pending.scenario(), Math.max(gainAvg, gainP95));
             successTracker.recordSuccess(pending.capability());
         }
@@ -511,6 +522,25 @@ public final class GovernorRunner {
                 .orElse(pending.baselineP95Ms());
     }
 
+    private ActionOutcome evaluateOutcomeFallback(PerfSnapshot baselineSnapshot, PerfSnapshot currentSnapshot) {
+        if (baselineSnapshot == null || currentSnapshot == null) {
+            return ActionOutcome.NEUTRAL;
+        }
+        double avgDelta = resolveDelta(currentSnapshot, baselineSnapshot, PerfSnapshot::avgFrametimeMs);
+        double p95Delta = resolveDelta(currentSnapshot, baselineSnapshot, PerfSnapshot::p95FrametimeMs);
+        boolean avgValid = isValidPerfValue(currentSnapshot.avgFrametimeMs())
+                && isValidPerfValue(baselineSnapshot.avgFrametimeMs());
+        boolean p95Valid = isValidPerfValue(currentSnapshot.p95FrametimeMs())
+                && isValidPerfValue(baselineSnapshot.p95FrametimeMs());
+        if (!avgValid && !p95Valid) {
+            return ActionOutcome.NEUTRAL;
+        }
+        if ((avgValid && avgDelta < 0) || (p95Valid && p95Delta < 0)) {
+            return ActionOutcome.POSITIVE;
+        }
+        return ActionOutcome.NEGATIVE;
+    }
+
     private String resolveActionSummary(RuntimeState state, PendingAction pending) {
         for (ActionHistoryEntry entry : state.actionHistory()) {
             if (entry.timestampMillis() == pending.timestampMillis()) {
@@ -522,6 +552,35 @@ public final class GovernorRunner {
 
     private boolean isValidPerfValue(double value) {
         return Double.isFinite(value) && value > 0;
+    }
+
+    private double resolveDelta(
+            PerfSnapshot currentSnapshot,
+            PerfSnapshot baselineSnapshot,
+            ToDoubleFunction<PerfSnapshot> extractor) {
+        if (currentSnapshot == null || baselineSnapshot == null) {
+            return 0.0;
+        }
+        double currentValue = extractor.applyAsDouble(currentSnapshot);
+        double baselineValue = extractor.applyAsDouble(baselineSnapshot);
+        if (!isValidPerfValue(currentValue) || !isValidPerfValue(baselineValue)) {
+            return 0.0;
+        }
+        return currentValue - baselineValue;
+    }
+
+    private int resolveSpikeDelta(PerfSnapshot currentSnapshot, PerfSnapshot baselineSnapshot) {
+        if (currentSnapshot == null || baselineSnapshot == null) {
+            return 0;
+        }
+        return currentSnapshot.spikeCount() - baselineSnapshot.spikeCount();
+    }
+
+    private double resolveGain(double baselineMs, double currentMs) {
+        if (!isValidPerfValue(baselineMs) || !isValidPerfValue(currentMs)) {
+            return 0.0;
+        }
+        return Math.max(0.0, baselineMs - currentMs);
     }
 
     private boolean attemptProviderRollback(PendingAction pending) {

--- a/src/main/java/dev/nozh/core/intelligence/SessionLearning.java
+++ b/src/main/java/dev/nozh/core/intelligence/SessionLearning.java
@@ -4,6 +4,9 @@ import dev.nozh.core.bus.CapabilityId;
 import dev.nozh.NozhConstants;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import java.io.File;
 import java.io.FileReader;
@@ -33,6 +36,7 @@ public final class SessionLearning {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static final long SAVE_INTERVAL_MILLIS = 60000;
 
+    private static final String DEFAULT_SESSION_KEY = "DEFAULT";
     private final Map<String, ActionStats> history = new HashMap<>();
     private final File statsFile;
     private final Path statsPath;
@@ -40,12 +44,33 @@ public final class SessionLearning {
     private int lastSavedHash = 0;
     private long lastSaveMillis = 0;
     private boolean dirty = false;
+    private String sessionKey = DEFAULT_SESSION_KEY;
 
     public SessionLearning(File configDir) {
         this.statsFile = new File(configDir, STATS_FILE);
         this.statsPath = statsFile.toPath();
         this.tmpPath = new File(configDir, STATS_TMP_FILE).toPath();
         load();
+    }
+
+    public void resetForSession(String newSessionKey) {
+        String normalizedKey = normalizeSessionKey(newSessionKey);
+        if (normalizedKey.equals(sessionKey)) {
+            return;
+        }
+        sessionKey = normalizedKey;
+        history.clear();
+        lastSavedHash = 0;
+        lastSaveMillis = 0;
+        dirty = true;
+        safeLog("Session learning reset for new session ({})", sessionKey);
+    }
+
+    private String normalizeSessionKey(String newSessionKey) {
+        if (newSessionKey == null || newSessionKey.isBlank()) {
+            return DEFAULT_SESSION_KEY;
+        }
+        return newSessionKey.trim();
     }
 
     /**
@@ -201,7 +226,7 @@ public final class SessionLearning {
                 parent.mkdirs();
             }
 
-            String json = GSON.toJson(history);
+            String json = GSON.toJson(new SessionData(sessionKey, history));
             int currentHash = json.hashCode();
             if (!force && currentHash == lastSavedHash) {
                 dirty = false;
@@ -237,7 +262,7 @@ public final class SessionLearning {
             }
 
             try {
-                String json = GSON.toJson(history);
+                String json = GSON.toJson(new SessionData(sessionKey, history));
                 Files.writeString(statsPath, json, StandardCharsets.UTF_8,
                         StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
             } catch (IOException ignored) {
@@ -256,16 +281,37 @@ public final class SessionLearning {
         }
 
         try (FileReader reader = new FileReader(statsFile)) {
-            java.lang.reflect.Type type = new com.google.gson.reflect.TypeToken<Map<String, ActionStats>>() {
-            }.getType();
-            Map<String, ActionStats> loaded = GSON.fromJson(reader, type);
-
-            if (loaded != null) {
-                history.putAll(loaded);
-                lastSavedHash = GSON.toJson(history).hashCode();
-                lastSaveMillis = System.currentTimeMillis();
-                safeLog("Session learning loaded ({} entries)", history.size());
+            JsonElement element = JsonParser.parseReader(reader);
+            if (element != null && element.isJsonObject()) {
+                JsonObject object = element.getAsJsonObject();
+                if (object.has("history")) {
+                    SessionData data = GSON.fromJson(object, SessionData.class);
+                    if (data != null) {
+                        sessionKey = normalizeSessionKey(data.sessionKey);
+                        if (data.history != null) {
+                            history.putAll(data.history);
+                        }
+                    }
+                } else {
+                    java.lang.reflect.Type type = new com.google.gson.reflect.TypeToken<Map<String, ActionStats>>() {
+                    }.getType();
+                    Map<String, ActionStats> loaded = GSON.fromJson(object, type);
+                    if (loaded != null) {
+                        history.putAll(loaded);
+                    }
+                }
+            } else {
+                java.lang.reflect.Type type = new com.google.gson.reflect.TypeToken<Map<String, ActionStats>>() {
+                }.getType();
+                Map<String, ActionStats> loaded = GSON.fromJson(element, type);
+                if (loaded != null) {
+                    history.putAll(loaded);
+                }
             }
+
+            lastSavedHash = GSON.toJson(new SessionData(sessionKey, history)).hashCode();
+            lastSaveMillis = System.currentTimeMillis();
+            safeLog("Session learning loaded ({} entries)", history.size());
         } catch (Exception e) {
             safeWarn("Failed to load session stats: {}", e.getMessage());
         }
@@ -302,5 +348,15 @@ public final class SessionLearning {
         public long lastFailureTime = 0;
         public double totalFpsGain = 0.0;
         public double avgFpsGain = 0.0;
+    }
+
+    private static final class SessionData {
+        public String sessionKey;
+        public Map<String, ActionStats> history;
+
+        private SessionData(String sessionKey, Map<String, ActionStats> history) {
+            this.sessionKey = sessionKey;
+            this.history = history;
+        }
     }
 }

--- a/src/main/java/dev/nozh/core/matrix/ActionMatrix.java
+++ b/src/main/java/dev/nozh/core/matrix/ActionMatrix.java
@@ -32,6 +32,7 @@ public final class ActionMatrix {
 
     private static final double CONFIDENCE_WEIGHT = 0.65;
     private static final double EXPECTED_GAIN_WEIGHT = 0.35;
+    private static final double LEARNED_CONFIDENCE_WEIGHT = 0.3;
 
     private final ProviderRegistry registry;
     private final ActionSuccessTracker successTracker;
@@ -126,9 +127,11 @@ public final class ActionMatrix {
                     lastFailure,
                     envChanged,
                     now);
+            double learnedConfidence = sessionLearning.getSuccessRate(id, scenario);
+            double blendedConfidence = blendConfidence(confidence, learnedConfidence);
 
             // Filter by confidence threshold
-            if (confidence < policy.minConfidence()) {
+            if (blendedConfidence < policy.minConfidence()) {
                 continue;
             }
 
@@ -168,8 +171,8 @@ public final class ActionMatrix {
                     metadata.rollbackGuarantee(),
                     metadata.gameplayImpact(),
                     metadata.visualImpact(),
-                    confidence,
-                    generateReason(id, confidence, metadata));
+                    blendedConfidence,
+                    generateReason(id, blendedConfidence, metadata));
 
             // Filter by allowed tiers
             if (!policy.allowedTiers().contains(candidate.tier())) {
@@ -239,8 +242,10 @@ public final class ActionMatrix {
                     lastFailure,
                     envChanged,
                     now);
+            double learnedConfidence = sessionLearning.getSuccessRate(id, scenario);
+            double blendedConfidence = blendConfidence(confidence, learnedConfidence);
 
-            if (confidence < policy.minConfidence()) {
+            if (blendedConfidence < policy.minConfidence()) {
                 continue;
             }
 
@@ -253,7 +258,7 @@ public final class ActionMatrix {
                     metadata.rollbackGuarantee(),
                     metadata.gameplayImpact(),
                     metadata.visualImpact(),
-                    confidence,
+                    blendedConfidence,
                     String.format("%s → restore baseline (%s profile)", id.name(), profile.name())));
         }
 
@@ -465,6 +470,11 @@ public final class ActionMatrix {
     private double scoreCandidate(ActionCandidate candidate, double maxExpectedGain) {
         double normalizedGain = maxExpectedGain > 0 ? candidate.expectedGainMs() / maxExpectedGain : 0.0;
         return (candidate.confidenceScore() * CONFIDENCE_WEIGHT) + (normalizedGain * EXPECTED_GAIN_WEIGHT);
+    }
+
+    private double blendConfidence(double baseConfidence, double learnedConfidence) {
+        return (baseConfidence * (1.0 - LEARNED_CONFIDENCE_WEIGHT))
+                + (learnedConfidence * LEARNED_CONFIDENCE_WEIGHT);
     }
 
     private boolean isQualityIncrease(CapabilityId id, CapabilityValue current, CapabilityValue baseline) {


### PR DESCRIPTION
### Motivation

- Weight action selection by per-session learned confidence so the governor prefers actions that worked on this machine and scenario. 
- Ensure action evaluation records success/failure even if telemetry is partial or delayed. 
- Persist learning per-play session (world/server) and reset when the player changes world to avoid cross-world contamination. 
- Keep persistence backward-compatible with existing stats file format.

### Description

- Added session scoping to `SessionLearning` with a `sessionKey`, `resetForSession(...)`, and a `SessionData` wrapper so saves include the active session and loading supports both the new object and the old plain-map formats. 
- Integrated session-learned success rates into `ActionMatrix` by calling `sessionLearning.getSuccessRate(...)` and blending it with the computed confidence (new `LEARNED_CONFIDENCE_WEIGHT` and `blendConfidence(...)`) before filtering and creating `ActionCandidate`s. 
- Hardened pending-action outcome evaluation in `GovernorRunner`: handle null/insufficient `PerfSnapshot`s, provide `evaluateOutcomeFallback(...)`, compute deltas via `resolveDelta`/`resolveSpikeDelta`, compute gain with `resolveGain(...)`, and avoid automatic rollback when telemetry is insufficient. 
- Reset session learning on world/server join in `NozhModClient` by deriving a session key (local level name or remote address), calling `sessionLearning.resetForSession(...)`, and saving; track `lastSessionKey` to avoid unnecessary resets.

### Testing

- No automated test suite was executed as part of this change. 
- Existing unit tests covering `SessionLearning` and `ActionMatrix` remain available in `src/test/java` and should be run (`./gradlew test`) to validate behavior against the new session format and blended confidence logic. 
- Loading remains backward-compatible with the previous JSON layout and will be exercised by integration/unit tests when run. 
- Manual verification was not included in automated steps here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959fef76ac4832d8da84d41979e50fc)