### PR TITLE
Add ActionMatrix, StateStore concurrency, and SessionLearning unit tests

### DIFF
--- a/src/test/java/dev/nozh/core/intelligence/SessionLearningTest.java
+++ b/src/test/java/dev/nozh/core/intelligence/SessionLearningTest.java
@@ -1,6 +1,7 @@
 package dev.nozh.core.intelligence;
 
 import dev.nozh.core.bus.CapabilityId;
+import dev.nozh.core.context.Scenario;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -59,5 +60,23 @@ class SessionLearningTest {
 
         assertTrue(learning.getRanking(CapabilityId.RENDER_DISTANCE)
                 > learning.getRanking(CapabilityId.CLOUDS));
+    }
+
+    @Test
+    void resetForSessionClearsScenarioHistory() {
+        SessionLearning learning = new SessionLearning(tempDir.toFile());
+
+        learning.recordSuccess(CapabilityId.PARTICLES, Scenario.COMBAT, 1.0);
+        learning.recordFailure(CapabilityId.CLOUDS);
+        learning.recordFailure(CapabilityId.CLOUDS);
+        learning.recordFailure(CapabilityId.CLOUDS);
+
+        assertTrue(learning.shouldAvoid(CapabilityId.CLOUDS, Scenario.COMBAT));
+        assertTrue(learning.getSuccessRate(CapabilityId.PARTICLES, Scenario.COMBAT) > 0.5);
+
+        learning.resetForSession("new-session");
+
+        assertEquals(0.5, learning.getSuccessRate(CapabilityId.PARTICLES, Scenario.COMBAT), 1e-6);
+        assertFalse(learning.shouldAvoid(CapabilityId.CLOUDS, Scenario.COMBAT));
     }
 }

--- a/src/test/java/dev/nozh/core/matrix/ActionMatrixTest.java
+++ b/src/test/java/dev/nozh/core/matrix/ActionMatrixTest.java
@@ -160,6 +160,37 @@ class ActionMatrixTest {
         assertEquals("OFF", candidateValue(byId.get(CapabilityId.CLOUDS)));
     }
 
+    @Test
+    void ranksCandidatesBySessionLearningAndPreservesRollbackGuarantee() {
+        ProviderMetadata cloudsMetadata = metadata(ImpactLevel.LOW, ImpactLevel.LOW, SafetyLevel.SAFE, 2.0,
+                RollbackGuarantee.BEST_EFFORT);
+        ProviderMetadata particlesMetadata = metadata(ImpactLevel.LOW, ImpactLevel.LOW, SafetyLevel.SAFE, 2.0,
+                RollbackGuarantee.STRONG);
+        ProviderRegistry registry = registryWith(
+                provider(CapabilityId.CLOUDS, cloudsMetadata),
+                provider(CapabilityId.PARTICLES, particlesMetadata));
+
+        ActionSuccessTracker tracker = successTrackerWith(CapabilityId.CLOUDS, CapabilityId.PARTICLES);
+        SessionLearning learning = new SessionLearning(tempDir.toFile());
+        learning.recordSuccess(CapabilityId.CLOUDS, Scenario.STANDARD, 2.0);
+        learning.recordSuccess(CapabilityId.CLOUDS, Scenario.STANDARD, 2.5);
+        learning.recordSuccess(CapabilityId.PARTICLES, Scenario.STANDARD, 0.1);
+
+        ActionMatrix matrix = new ActionMatrix(
+                registry,
+                tracker,
+                new ConfidenceCalculator(),
+                learning);
+
+        List<ActionCandidate> candidates = matrix.generateCandidates(ModePolicy.manualAssist(), "BALANCED",
+                Scenario.STANDARD, OptimizationProfile.BALANCED, -1.0, 0);
+
+        assertEquals(2, candidates.size());
+        assertEquals(CapabilityId.CLOUDS, candidates.get(0).capabilityId());
+        assertEquals(RollbackGuarantee.BEST_EFFORT, candidates.get(0).rollbackGuarantee());
+        assertEquals(RollbackGuarantee.STRONG, candidates.get(1).rollbackGuarantee());
+    }
+
     private ProviderRegistry registryWith(CapabilityProvider... providers) {
         ProviderRegistry registry = new ProviderRegistry(new ProviderHealthTracker());
         for (CapabilityProvider provider : providers) {
@@ -205,10 +236,19 @@ class ActionMatrixTest {
             ImpactLevel visualImpact,
             SafetyLevel safetyLevel,
             double expectedGain) {
+        return metadata(gameplayImpact, visualImpact, safetyLevel, expectedGain, RollbackGuarantee.STRONG);
+    }
+
+    private ProviderMetadata metadata(
+            ImpactLevel gameplayImpact,
+            ImpactLevel visualImpact,
+            SafetyLevel safetyLevel,
+            double expectedGain,
+            RollbackGuarantee rollbackGuarantee) {
         return new TestProviderMetadata(
                 SideEffects.none(),
                 safetyLevel,
-                RollbackGuarantee.STRONG,
+                rollbackGuarantee,
                 gameplayImpact,
                 visualImpact,
                 expectedGain,

--- a/src/test/java/dev/nozh/core/state/StateStoreTest.java
+++ b/src/test/java/dev/nozh/core/state/StateStoreTest.java
@@ -2,6 +2,12 @@ package dev.nozh.core.state;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -18,6 +24,59 @@ class StateStoreTest {
 
             store.markPersisted();
             assertFalse(store.isDirty());
+        } finally {
+            store.reset();
+        }
+    }
+
+    @Test
+    void supportsConcurrentSnapshotsAndUpdates() throws InterruptedException {
+        StateStore store = StateStore.getInstance();
+        store.reset();
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(4);
+        ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+        Runnable updater = () -> {
+            try {
+                startLatch.await();
+                for (int i = 0; i < 100; i++) {
+                    store.update(state -> state.withDecision("thread-" + Thread.currentThread().getId(), System.nanoTime()));
+                }
+            } catch (Throwable t) {
+                errors.add(t);
+            } finally {
+                doneLatch.countDown();
+            }
+        };
+
+        Runnable reader = () -> {
+            try {
+                startLatch.await();
+                for (int i = 0; i < 100; i++) {
+                    store.snapshot();
+                    store.snapshotSafe();
+                }
+            } catch (Throwable t) {
+                errors.add(t);
+            } finally {
+                doneLatch.countDown();
+            }
+        };
+
+        executor.execute(updater);
+        executor.execute(updater);
+        executor.execute(reader);
+        executor.execute(reader);
+
+        startLatch.countDown();
+        doneLatch.await(5, TimeUnit.SECONDS);
+        executor.shutdownNow();
+
+        try {
+            assertTrue(errors.isEmpty());
         } finally {
             store.reset();
         }


### PR DESCRIPTION
### Motivation
- Improve core coverage for decision-making by exercising `ActionMatrix` behaviour under session learning influence.
- Verify `StateStore` thread-safety with concurrent snapshot/read and transactional updates to protect core invariants.
- Ensure `SessionLearning` scenario-scoped behaviour and reset semantics are correct and persist/restore as expected.

### Description
- Added tests in `src/test/java/dev/nozh/core/matrix/ActionMatrixTest.java` to assert candidate ordering by `SessionLearning` and propagation of `RollbackGuarantee` metadata via a test `CapabilityProvider`.
- Added a concurrency test in `src/test/java/dev/nozh/core/state/StateStoreTest.java` that runs multiple updaters and readers in parallel to validate `snapshot()`/`snapshotSafe()` and `update()` under contention.
- Added a scenario-reset test in `src/test/java/dev/nozh/core/intelligence/SessionLearningTest.java` to validate `resetForSession()` clears scenario history and affects `shouldAvoid`/`getSuccessRate` as intended.
- Extended test helpers to allow specifying `RollbackGuarantee` for providers by adding an overloaded `metadata(...)` helper used by `TestProvider` in the matrix tests.

### Testing
- Added unit tests: `ActionMatrixTest`, `StateStoreTest`, and `SessionLearningTest` (new test cases described above) and ran an attempted local test run with `bash ./gradlew test`.
- The test run failed to start the Gradle wrapper due to an external proxy error: `HTTP/1.1 403 Forbidden` when downloading the Gradle distribution, so automated tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bb275162c832d824f3939d7c2bd32)