### PR TITLE
Add benchmark session export, crash-loop audit metrics, and unit tests for learning/state/rollback

### DIFF
--- a/docs/modpack-quick-test.md
+++ b/docs/modpack-quick-test.md
@@ -1,0 +1,41 @@
+# Protocolo rápido de test para modpacks
+
+Este protocolo está pensado para ejecutar una validación rápida (10-15 min)
+en modpacks, con foco en escenarios comunes donde el rendimiento suele
+degradarse. Úsalo como checklist para capturar señales rápidas de regresión.
+
+## Preparación (1-2 min)
+- Reinicia el cliente para arrancar una sesión limpia.
+- Asegúrate de que NOZH esté habilitado y con HUD visible.
+- Si existe un preset de config para el modpack, cárgalo antes de iniciar.
+
+## Escenarios típicos (8-10 min)
+
+### 1) Mobs (combate / entidades)
+1. Dirígete a una zona con alta densidad de entidades (spawner o granja).
+2. Observa frametime y spikes durante 2-3 minutos.
+3. Anota si hay fluctuaciones fuertes al abrir inventario o atacar.
+
+### 2) Minería (subterráneo / partículas)
+1. Mina en una cueva con agua, lava y partículas activas.
+2. Verifica que el frametime se mantenga estable al generar nuevos chunks.
+3. Confirma que los cambios sugeridos no degraden la jugabilidad.
+
+### 3) Nether (carga y efectos)
+1. Entra al nether y recorre biomas con efectos de partículas.
+2. Observa spikes en teleports o cambios de bioma.
+3. Confirma que la visión no se degrade de forma inesperada.
+
+### 4) Lluvia (clima / shaders)
+1. Fuerza lluvia si el modpack lo permite (o espera a clima natural).
+2. Valida que no aumente el p95 frametime de forma sostenida.
+3. Comprueba si hay necesidad de rollback automático o sugerencias.
+
+## Cierre (1-2 min)
+- Revisa el historial de acciones para validar decisiones y rollback.
+- Si se detecta regressión, exporta telemetría y adjunta el reporte.
+
+## Señales rápidas de regresión
+- p95 frametime sube > 2 ms vs baseline en 2+ escenarios.
+- Spike count aumenta de forma sostenida al cambiar de dimensión.
+- Rollback no recupera calidad visual cuando el rendimiento mejora.

--- a/src/main/java/dev/nozh/core/profiler/BenchmarkSession.java
+++ b/src/main/java/dev/nozh/core/profiler/BenchmarkSession.java
@@ -1,0 +1,95 @@
+package dev.nozh.core.profiler;
+
+import dev.nozh.api.PerfSnapshot;
+import dev.nozh.core.telemetry.TelemetryExportFormat;
+import dev.nozh.core.telemetry.TelemetryExportWriter;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+/**
+ * Controlled-input benchmark session for performance reports.
+ *
+ * Allows tests and tooling to inject deterministic frametime samples and
+ * generate an exportable report without relying on live frame hooks.
+ */
+public final class BenchmarkSession {
+
+    private static final int MIN_CAPACITY = 60;
+    private static final int MAX_CAPACITY = 600;
+
+    private final RollingWindowStats stats;
+    private final int windowSeconds;
+    private final int capacity;
+    private final long startedAtMillis;
+
+    public BenchmarkSession(int targetFps, int windowSeconds) {
+        if (targetFps <= 0) {
+            throw new IllegalArgumentException("targetFps must be positive");
+        }
+        if (windowSeconds <= 0) {
+            throw new IllegalArgumentException("windowSeconds must be positive");
+        }
+        this.windowSeconds = windowSeconds;
+        this.capacity = calculateCapacity(targetFps, windowSeconds);
+        this.stats = new RollingWindowStats(capacity, windowSeconds);
+        this.startedAtMillis = System.currentTimeMillis();
+    }
+
+    public void addSampleNanos(long nanos) {
+        if (nanos <= 0) {
+            return;
+        }
+        stats.addSample(nanos);
+    }
+
+    public void addSampleMillis(double millis) {
+        if (!Double.isFinite(millis) || millis <= 0.0) {
+            return;
+        }
+        stats.addSample((long) (millis * 1_000_000.0));
+    }
+
+    public void addSamplesNanos(long[] samples) {
+        if (samples == null) {
+            return;
+        }
+        for (long sample : samples) {
+            addSampleNanos(sample);
+        }
+    }
+
+    public PerfSnapshot snapshot() {
+        return stats.snapshot();
+    }
+
+    public long[] snapshotSamplesNanos() {
+        return stats.snapshotSamplesNanos();
+    }
+
+    public BenchmarkSessionReport exportReport(Path outputDir, TelemetryExportFormat format, String label)
+            throws Exception {
+        Objects.requireNonNull(outputDir, "outputDir");
+        Objects.requireNonNull(format, "format");
+        Files.createDirectories(outputDir);
+        PerfSnapshot snapshot = stats.snapshot();
+        long[] samples = stats.snapshotSamplesNanos();
+        String timestamp = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
+                .withZone(ZoneOffset.UTC)
+                .format(Instant.ofEpochMilli(snapshot.timestampMillis()));
+        String sanitizedLabel = label != null && !label.isBlank() ? label.trim().replaceAll("\\s+", "_") : "session";
+        String extension = format == TelemetryExportFormat.CSV ? "csv" : "json";
+        Path outputFile = outputDir.resolve("benchmark_" + sanitizedLabel + "_" + timestamp + "." + extension);
+        TelemetryExportWriter.write(snapshot, samples, outputFile, format);
+        return new BenchmarkSessionReport(snapshot, samples, outputFile, format, windowSeconds, capacity, startedAtMillis);
+    }
+
+    private int calculateCapacity(int targetFps, int windowSeconds) {
+        int calcCapacity = targetFps * windowSeconds;
+        return Math.max(MIN_CAPACITY, Math.min(calcCapacity, MAX_CAPACITY));
+    }
+}

--- a/src/main/java/dev/nozh/core/profiler/BenchmarkSessionReport.java
+++ b/src/main/java/dev/nozh/core/profiler/BenchmarkSessionReport.java
@@ -1,0 +1,19 @@
+package dev.nozh.core.profiler;
+
+import dev.nozh.api.PerfSnapshot;
+import dev.nozh.core.telemetry.TelemetryExportFormat;
+
+import java.nio.file.Path;
+
+/**
+ * Report metadata for a benchmark session export.
+ */
+public record BenchmarkSessionReport(
+        PerfSnapshot snapshot,
+        long[] samplesNanos,
+        Path reportPath,
+        TelemetryExportFormat format,
+        int windowSeconds,
+        int capacity,
+        long startedAtMillis) {
+}

--- a/src/main/java/dev/nozh/core/safety/CrashLoopAuditMetrics.java
+++ b/src/main/java/dev/nozh/core/safety/CrashLoopAuditMetrics.java
@@ -1,0 +1,55 @@
+package dev.nozh.core.safety;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Audit-friendly crash loop and safe mode metrics snapshot.
+ */
+public record CrashLoopAuditMetrics(
+        int bootAttempts,
+        boolean sessionStable,
+        boolean safeModeActive,
+        String safeModeReason,
+        Set<SafeModeCause> safeModeCauses,
+        long safeModeActivatedAt,
+        long lastCleanShutdown,
+        long sessionStartTime,
+        int ticksSinceStart,
+        boolean initialized,
+        boolean crashLoopDetected) {
+
+    public static CrashLoopAuditMetrics empty(int ticksSinceStart, boolean initialized) {
+        return new CrashLoopAuditMetrics(
+                0,
+                false,
+                false,
+                "off",
+                EnumSet.noneOf(SafeModeCause.class),
+                0L,
+                0L,
+                0L,
+                ticksSinceStart,
+                initialized,
+                false);
+    }
+
+    public static CrashLoopAuditMetrics fromState(NozhState state, int ticksSinceStart, boolean initialized,
+            boolean crashLoopDetected) {
+        Set<SafeModeCause> causes = state.safeModeCauses != null && !state.safeModeCauses.isEmpty()
+                ? EnumSet.copyOf(state.safeModeCauses)
+                : EnumSet.noneOf(SafeModeCause.class);
+        return new CrashLoopAuditMetrics(
+                state.bootAttempts,
+                state.sessionStable,
+                state.isSafeModeActive(),
+                state.getSafeModeReason(),
+                causes,
+                state.safeModeActivatedAt,
+                state.lastCleanShutdown,
+                state.sessionStartTime,
+                ticksSinceStart,
+                initialized,
+                crashLoopDetected);
+    }
+}

--- a/src/main/java/dev/nozh/core/safety/CrashLoopGuard.java
+++ b/src/main/java/dev/nozh/core/safety/CrashLoopGuard.java
@@ -200,6 +200,27 @@ public final class CrashLoopGuard {
         return (state != null) && state.sessionStable;
     }
 
+    /**
+     * Check if current state indicates a crash loop.
+     */
+    public static boolean isCrashLoopDetected() {
+        NozhState state = StateManager.getState();
+        return shouldEnterSafeMode(state);
+    }
+
+    /**
+     * Get audit-friendly metrics for safe mode and crash-loop checks.
+     */
+    public static CrashLoopAuditMetrics getAuditMetrics() {
+        synchronized (LOCK) {
+            NozhState state = StateManager.getState();
+            if (state == null) {
+                return CrashLoopAuditMetrics.empty(ticksSinceStart, initialized);
+            }
+            return CrashLoopAuditMetrics.fromState(state, ticksSinceStart, initialized, shouldEnterSafeMode(state));
+        }
+    }
+
     private static boolean shouldEnterSafeMode(NozhState state) {
         if (state == null) {
             return false;

--- a/src/test/java/dev/nozh/core/intelligence/SessionLearningTest.java
+++ b/src/test/java/dev/nozh/core/intelligence/SessionLearningTest.java
@@ -79,4 +79,15 @@ class SessionLearningTest {
         assertEquals(0.5, learning.getSuccessRate(CapabilityId.PARTICLES, Scenario.COMBAT), 1e-6);
         assertFalse(learning.shouldAvoid(CapabilityId.CLOUDS, Scenario.COMBAT));
     }
+
+    @Test
+    void tracksPredictionAccuracyAcrossSessions() {
+        SessionLearning learning = new SessionLearning(tempDir.toFile());
+        learning.recordPredictionOutcome(true, true, 0.8);
+        learning.recordPredictionOutcome(false, true, 0.4);
+        learning.save();
+
+        SessionLearning reloaded = new SessionLearning(tempDir.toFile());
+        assertTrue(reloaded.getPredictionAccuracy() > 0.0);
+    }
 }

--- a/src/test/java/dev/nozh/core/matrix/ActionMatrixTest.java
+++ b/src/test/java/dev/nozh/core/matrix/ActionMatrixTest.java
@@ -17,6 +17,7 @@ import dev.nozh.core.context.Scenario;
 import dev.nozh.core.governor.ModePolicy;
 import dev.nozh.core.governor.OptimizationProfile;
 import dev.nozh.core.intelligence.SessionLearning;
+import dev.nozh.core.state.BaselineSnapshot;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -190,6 +191,35 @@ class ActionMatrixTest {
         assertEquals(CapabilityId.CLOUDS, candidates.get(0).capabilityId());
         assertEquals(RollbackGuarantee.BEST_EFFORT, candidates.get(0).rollbackGuarantee());
         assertEquals(RollbackGuarantee.STRONG, candidates.get(1).rollbackGuarantee());
+    }
+
+    @Test
+    void reverseCandidatesRestoreBaselineQuality() {
+        ProviderRegistry registry = registryWith(
+                provider(CapabilityId.RENDER_DISTANCE,
+                        metadata(ImpactLevel.LOW, ImpactLevel.LOW, SafetyLevel.SAFE, 1.0)));
+
+        ActionMatrix matrix = new ActionMatrix(
+                registry,
+                successTrackerWith(CapabilityId.RENDER_DISTANCE),
+                new ConfidenceCalculator(),
+                new SessionLearning(tempDir.toFile()));
+
+        BaselineSnapshot baseline = new BaselineSnapshot(Map.of(
+                CapabilityId.RENDER_DISTANCE, new CapabilityValue.IntValue(12)));
+        Map<CapabilityId, CapabilityValue> currentSettings = Map.of(
+                CapabilityId.RENDER_DISTANCE, new CapabilityValue.IntValue(8));
+
+        List<ActionCandidate> candidates = matrix.generateReverseCandidates(
+                ModePolicy.manualAssist(),
+                Scenario.STANDARD,
+                OptimizationProfile.BALANCED,
+                baseline,
+                currentSettings);
+
+        assertEquals(1, candidates.size());
+        assertEquals("12", candidateValue(candidates.get(0)));
+        assertTrue(candidates.get(0).reason().contains("restore baseline"));
     }
 
     private ProviderRegistry registryWith(CapabilityProvider... providers) {

--- a/src/test/java/dev/nozh/core/state/BaselineSnapshotTest.java
+++ b/src/test/java/dev/nozh/core/state/BaselineSnapshotTest.java
@@ -1,0 +1,35 @@
+package dev.nozh.core.state;
+
+import dev.nozh.core.bus.CapabilityId;
+import dev.nozh.core.bus.CapabilityValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BaselineSnapshotTest {
+
+    @Test
+    void clampsRollbackToBaseline() {
+        BaselineSnapshot baseline = new BaselineSnapshot(Map.of(
+                CapabilityId.RENDER_DISTANCE, new CapabilityValue.IntValue(10)));
+        CapabilityValue candidate = new CapabilityValue.IntValue(16);
+
+        assertTrue(baseline.exceedsBaseline(CapabilityId.RENDER_DISTANCE, candidate));
+        assertEquals(new CapabilityValue.IntValue(10),
+                baseline.clampToBaseline(CapabilityId.RENDER_DISTANCE, candidate));
+    }
+
+    @Test
+    void keepsCandidateWhenWithinBaseline() {
+        BaselineSnapshot baseline = new BaselineSnapshot(Map.of(
+                CapabilityId.PARTICLES, new CapabilityValue.EnumValue("DECREASED")));
+        CapabilityValue candidate = new CapabilityValue.EnumValue("MINIMAL");
+
+        assertFalse(baseline.exceedsBaseline(CapabilityId.PARTICLES, candidate));
+        assertEquals(candidate, baseline.clampToBaseline(CapabilityId.PARTICLES, candidate));
+    }
+}

--- a/src/test/java/dev/nozh/core/state/StateStoreTest.java
+++ b/src/test/java/dev/nozh/core/state/StateStoreTest.java
@@ -1,5 +1,6 @@
 package dev.nozh.core.state;
 
+import dev.nozh.core.config.NozhConfig;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -9,6 +10,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StateStoreTest {
@@ -43,7 +45,8 @@ class StateStoreTest {
             try {
                 startLatch.await();
                 for (int i = 0; i < 100; i++) {
-                    store.update(state -> state.withDecision("thread-" + Thread.currentThread().getId(), System.nanoTime()));
+                    store.update(state -> state.withDecision("thread-" + Thread.currentThread().getId(),
+                            System.nanoTime()));
                 }
             } catch (Throwable t) {
                 errors.add(t);
@@ -77,6 +80,23 @@ class StateStoreTest {
 
         try {
             assertTrue(errors.isEmpty());
+        } finally {
+            store.reset();
+        }
+    }
+
+    @Test
+    void updateRejectsInvalidState() {
+        StateStore store = StateStore.getInstance();
+        store.reset();
+
+        NozhConfig config = new NozhConfig();
+        config.safeModeForce = true;
+        config.allowAutoTuning = true;
+
+        try {
+            assertThrows(StateInvariantViolationException.class,
+                    () -> store.update(state -> RuntimeState.fromConfig(config)));
         } finally {
             store.reset();
         }


### PR DESCRIPTION
### Motivation
- Provide a controlled, reproducible "benchmark session" mode so tooling and tests can inject deterministic samples and generate perf reports without live frame hooks.
- Improve regression coverage for rollback / quality‑recovery logic and session learning to reduce risk of silent regressions.
- Expose auditable metrics for safe mode and crash‑loop detection so operators can reason about why the system entered safe mode.
- Offer a short, practical modpack quick‑test protocol to standardize manual verification scenarios.

### Description
- Added `dev.nozh.core.profiler.BenchmarkSession` and `BenchmarkSessionReport` to create controlled-input benchmark runs and export reports via the existing `TelemetryExportWriter` API.
- Introduced `dev.nozh.core.safety.CrashLoopAuditMetrics` and added `isCrashLoopDetected()` and `getAuditMetrics()` helpers to `CrashLoopGuard` for audit‑friendly safe mode metrics.
- Added and updated JUnit tests: `SessionLearningTest` (prediction/serialization/avoidance), `BaselineSnapshotTest` (baseline clamp behavior), extended `ActionMatrixTest` with a reverse/restore baseline test, and `StateStoreTest` with concurrency and invalid‑state validation scenarios.
- Added `docs/modpack-quick-test.md` as a short protocol for common modpack validation scenarios and small adjustments to state/guard code to support metrics.

### Testing
- No automated tests were executed as part of this PR; CI/test runs were not performed here.
- Unit tests added: `SessionLearningTest`, `BaselineSnapshotTest`, extended `ActionMatrixTest`, and `StateStoreTest` for concurrency and invariant validation (JUnit).
- The new profiler API is file‑based and uses existing `TelemetryExportWriter` for CSV/JSON exports and can be exercised via `BenchmarkSession` in tests or tools.
- To run the test suite locally, execute `./gradlew test` to validate the new and existing unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd7a12a08832d84c12e1e88fbaa32)