### PR TITLE
Wire scenario detector hooks for gameplay actions and add telemetry logging

### DIFF
--- a/src/main/java/dev/nozh/client/NozhModClient.java
+++ b/src/main/java/dev/nozh/client/NozhModClient.java
@@ -59,6 +59,7 @@ public class NozhModClient implements ClientModInitializer {
     private static ConfigSyncService configSyncService;
     private static dev.nozh.core.intelligence.SessionLearning sessionLearning;
     private static ProviderRegistry providerRegistry;
+    private static dev.nozh.fabric.context.FabricScenarioDetector scenarioDetector;
     private static KeyBinding toggleHudKey;
     private static KeyBinding applySuggestionKey;
     private static boolean safeModeNotified = false;
@@ -137,7 +138,7 @@ public class NozhModClient implements ClientModInitializer {
 
         // Create ScenarioDetector (Fabric implementation) - FIXED: Added MinecraftClient parameter
         MinecraftClient client = MinecraftClient.getInstance();
-        dev.nozh.core.context.ScenarioDetector scenarioDetector = new dev.nozh.fabric.context.FabricScenarioDetector(client);
+        scenarioDetector = new dev.nozh.fabric.context.FabricScenarioDetector(client);
 
         // 9. Create GovernorRunner with all dependencies
         governorRunner = new GovernorRunner(
@@ -195,6 +196,10 @@ public class NozhModClient implements ClientModInitializer {
             // Sample tick time (must be called once per tick)
             tickTimeSampler.onTick();
 
+            if (scenarioDetector != null) {
+                scenarioDetector.tick();
+            }
+
             if (toggleHudKey != null) {
                 while (toggleHudKey.wasPressed()) {
                     var config = ConfigManager.getConfig();
@@ -219,6 +224,9 @@ public class NozhModClient implements ClientModInitializer {
             // Update RuntimeState with telemetry data every second
             if (tickCounter % TELEMETRY_UPDATE_INTERVAL == 0) {
                 updateTelemetryState();
+                if (scenarioDetector != null) {
+                    scenarioDetector.logTelemetry();
+                }
             }
 
             // Run governor decision loop every 5 seconds
@@ -307,6 +315,10 @@ public class NozhModClient implements ClientModInitializer {
 
     public static StateStore getStateStore() {
         return stateStore;
+    }
+
+    public static dev.nozh.fabric.context.FabricScenarioDetector getScenarioDetector() {
+        return scenarioDetector;
     }
 
     public static KeyBinding getApplySuggestionKey() {

--- a/src/main/java/dev/nozh/fabric/context/FabricScenarioDetector.java
+++ b/src/main/java/dev/nozh/fabric/context/FabricScenarioDetector.java
@@ -4,6 +4,7 @@ import dev.nozh.core.context.Scenario;
 import dev.nozh.core.context.ScenarioConfidence;
 import dev.nozh.core.context.ScenarioDetector;
 import dev.nozh.core.context.ScenarioSnapshot;
+import dev.nozh.core.util.DebugLogger;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.mob.HostileEntity;
@@ -276,6 +277,29 @@ public final class FabricScenarioDetector implements ScenarioDetector {
     public void tick() {
         if (blocksPlacedRecent > 0) blocksPlacedRecent--;
         if (blocksBrokenRecent > 0) blocksBrokenRecent--;
+    }
+
+    public void logTelemetry() {
+        int attacks = countRecentActions(ActionType.ATTACK);
+        int damage = countRecentActions(ActionType.DAMAGE);
+        int inventory = countRecentActions(ActionType.INVENTORY);
+        DebugLogger.log("SCENARIO",
+                "Recent actions: attacks=" + attacks
+                        + " damage=" + damage
+                        + " placed=" + blocksPlacedRecent
+                        + " broken=" + blocksBrokenRecent
+                        + " inventory=" + inventory
+                        + " history=" + actionHistory.size());
+    }
+
+    private int countRecentActions(ActionType type) {
+        int count = 0;
+        for (PlayerAction action : actionHistory) {
+            if (action.type() == type) {
+                count++;
+            }
+        }
+        return count;
     }
 
     private record PlayerAction(long tick, ActionType type) {}

--- a/src/main/java/dev/nozh/mixin/MixinClientPlayerEntity.java
+++ b/src/main/java/dev/nozh/mixin/MixinClientPlayerEntity.java
@@ -1,0 +1,25 @@
+package dev.nozh.mixin;
+
+import dev.nozh.client.NozhModClient;
+import dev.nozh.fabric.context.FabricScenarioDetector;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.damage.DamageSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientPlayerEntity.class)
+public class MixinClientPlayerEntity {
+
+    @Inject(method = "damage", at = @At("HEAD"))
+    private void nozh$damage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> info) {
+        if (amount <= 0) {
+            return;
+        }
+        FabricScenarioDetector detector = NozhModClient.getScenarioDetector();
+        if (detector != null) {
+            detector.recordDamage();
+        }
+    }
+}

--- a/src/main/java/dev/nozh/mixin/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/dev/nozh/mixin/MixinClientPlayerInteractionManager.java
@@ -1,0 +1,54 @@
+package dev.nozh.mixin;
+
+import dev.nozh.client.NozhModClient;
+import dev.nozh.fabric.context.FabricScenarioDetector;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.hit.BlockHitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientPlayerInteractionManager.class)
+public class MixinClientPlayerInteractionManager {
+
+    @Inject(method = "attackEntity", at = @At("HEAD"))
+    private void nozh$attackEntity(PlayerEntity player, Entity target, CallbackInfo info) {
+        FabricScenarioDetector detector = NozhModClient.getScenarioDetector();
+        if (detector != null) {
+            detector.recordAttack();
+        }
+    }
+
+    @Inject(method = "attackBlock", at = @At("RETURN"))
+    private void nozh$attackBlock(BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> info) {
+        if (!Boolean.TRUE.equals(info.getReturnValue())) {
+            return;
+        }
+        FabricScenarioDetector detector = NozhModClient.getScenarioDetector();
+        if (detector != null) {
+            detector.recordBlockBroken();
+        }
+    }
+
+    @Inject(method = "interactBlock", at = @At("RETURN"))
+    private void nozh$interactBlock(ClientPlayerEntity player, Hand hand, BlockHitResult hitResult,
+                                    CallbackInfoReturnable<ActionResult> info) {
+        ActionResult result = info.getReturnValue();
+        if (result == null || !result.isAccepted()) {
+            return;
+        }
+        FabricScenarioDetector detector = NozhModClient.getScenarioDetector();
+        if (detector != null) {
+            detector.recordBlockPlaced();
+        }
+    }
+}

--- a/src/main/java/dev/nozh/mixin/MixinMinecraftClient.java
+++ b/src/main/java/dev/nozh/mixin/MixinMinecraftClient.java
@@ -1,0 +1,26 @@
+package dev.nozh.mixin;
+
+import dev.nozh.client.NozhModClient;
+import dev.nozh.fabric.context.FabricScenarioDetector;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftClient.class)
+public class MixinMinecraftClient {
+
+    @Inject(method = "setScreen", at = @At("HEAD"))
+    private void nozh$setScreen(Screen screen, CallbackInfo info) {
+        if (!(screen instanceof HandledScreen<?>)) {
+            return;
+        }
+        FabricScenarioDetector detector = NozhModClient.getScenarioDetector();
+        if (detector != null) {
+            detector.recordInventoryOpen();
+        }
+    }
+}

--- a/src/main/resources/nozh.mixins.json
+++ b/src/main/resources/nozh.mixins.json
@@ -4,6 +4,9 @@
     "compatibilityLevel": "JAVA_17",
     "mixins": [],
     "client": [
+        "MixinClientPlayerInteractionManager",
+        "MixinClientPlayerEntity",
+        "MixinMinecraftClient",
         "MixinKeyboard",
         "MixinMouse",
         "MixinEntityRenderDispatcher",


### PR DESCRIPTION
### Motivation

- Connect the Fabric `ScenarioDetector` implementation to real gameplay events so runtime scenario detection reflects player actions.  
- Capture attacks, received damage, block place/break and inventory opens to improve scenario accuracy and telemetry.  
- Expose the detector from the client initializer so other systems and mixins can record events.  
- Provide a minimal telemetry/logging surface to validate counters at runtime.

### Description

- Added mixins to record gameplay events: `MixinClientPlayerInteractionManager` records `attackEntity`, `attackBlock`, and `interactBlock`, `MixinClientPlayerEntity` hooks `damage`, and `MixinMinecraftClient` hooks `setScreen` to detect inventory opens.  
- Registered and stored a `FabricScenarioDetector` instance in `NozhModClient` via a new static field and `getScenarioDetector()` accessor, and instantiated it during client initialization.  
- Ticked the detector each client tick and added periodic telemetry logging by calling the detector's new `tick()` and `logTelemetry()` methods from the client tick loop.  
- Extended `FabricScenarioDetector` with `logTelemetry()` and `countRecentActions()` using the existing action history and `DebugLogger` to emit recent counters (`attacks`, `damage`, `placed`, `broken`, `inventory`, `history`), and updated `nozh.mixins.json` to include the new mixin classes.

### Testing

- No automated unit or integration tests were executed for this change.  
- Runtime validation is supported via the newly-added `logTelemetry()` debug logs when `debugLogs` is enabled in `NozhConfig`.  
- Basic compile-time integration was considered by wiring into the existing client tick and initialization flows, but no CI build was run here.  
- Manual runtime verification is expected (enable `debugLogs` and observe `SCENARIO` debug entries).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d1d5fde64832d86cbae05c67657b5)