### PR TITLE
Remove CHUNK_LOADING target path from ActionMatrix

### DIFF
--- a/src/main/java/dev/nozh/core/matrix/ActionMatrix.java
+++ b/src/main/java/dev/nozh/core/matrix/ActionMatrix.java
@@ -531,12 +531,6 @@ public final class ActionMatrix {
                     break;
                 }
             }
-            case CHUNK_LOADING -> {
-                if (loading || cpuBound) {
-                    targetValue = new CapabilityValue.EnumValue(aggressive ? "AGGRESSIVE" : "BALANCED");
-                    break;
-                }
-            }
             default -> {
             }
         }


### PR DESCRIPTION
### Motivation
- `CHUNK_LOADING` is declared in `CapabilityId` but there is no provider or `MinecraftOptionsAdapter` support to apply/read chunk-loading settings.
- The action-generation heuristics were producing a target for a capability that cannot be executed, which could lead to invalid action proposals.
- Remove the unsupported heuristic to prevent recommending non-implementable changes.

### Description
- Removed the `case CHUNK_LOADING` branch from `src/main/java/dev/nozh/core/matrix/ActionMatrix.java` (the `generateTargetValue` path that set `AGGRESSIVE`/`BALANCED`).
- Kept the `CapabilityId.CHUNK_LOADING` enum entry intact so it can be supported later if a provider/adapter is implemented.
- No provider was added and `ProviderBootstrap` was not modified.

### Testing
- No automated tests were executed for this change.
- No test failures were reported (no tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d278ee218832d9d588723e5379d02)