### PR TITLE
Implement GameRenderer, ArmorStand, and ItemFrame mixins with safe visibility decider

### DIFF
--- a/src/main/java/dev/nozh/core/render/RenderVisibilityDecider.java
+++ b/src/main/java/dev/nozh/core/render/RenderVisibilityDecider.java
@@ -1,0 +1,57 @@
+package dev.nozh.core.render;
+
+import dev.nozh.NozhConstants;
+import dev.nozh.core.settings.NozhRenderSettings;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+
+public final class RenderVisibilityDecider {
+
+    private static final Set<String> warnedLabels = ConcurrentHashMap.newKeySet();
+    private static final AtomicLong lastGameRendererFrameNanos = new AtomicLong();
+
+    private RenderVisibilityDecider() {
+    }
+
+    public static boolean isArmorStandVisible() {
+        return resolveVisibility(NozhRenderSettings::isArmorStandsVisible, "armor stand");
+    }
+
+    public static boolean isItemFrameVisible() {
+        return resolveVisibility(NozhRenderSettings::isItemFramesVisible, "item frame");
+    }
+
+    public static boolean isAllAnimationsVisible() {
+        return resolveVisibility(NozhRenderSettings::isAllAnimationsVisible, "animations");
+    }
+
+    public static void recordGameRendererFrame() {
+        safeRun(() -> lastGameRendererFrameNanos.set(System.nanoTime()), "game renderer frame");
+    }
+
+    public static boolean resolveVisibility(BooleanSupplier supplier, String label) {
+        try {
+            return supplier.getAsBoolean();
+        } catch (RuntimeException ex) {
+            warnOnce(label, ex);
+            return true;
+        }
+    }
+
+    private static void safeRun(Runnable runnable, String label) {
+        try {
+            runnable.run();
+        } catch (RuntimeException ex) {
+            warnOnce(label, ex);
+        }
+    }
+
+    private static void warnOnce(String label, RuntimeException ex) {
+        if (warnedLabels.add(label)) {
+            NozhConstants.LOGGER.warn("Render visibility check failed for {}. Falling back to visible.", label, ex);
+        }
+    }
+}

--- a/src/main/java/dev/nozh/mixin/MixinArmorStandEntity.java
+++ b/src/main/java/dev/nozh/mixin/MixinArmorStandEntity.java
@@ -1,0 +1,19 @@
+package dev.nozh.mixin;
+
+import dev.nozh.core.render.RenderVisibilityDecider;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ArmorStandEntity.class)
+public class MixinArmorStandEntity {
+
+    @Inject(method = "isInvisible", at = @At("HEAD"), cancellable = true)
+    private void nozh$forceInvisible(CallbackInfoReturnable<Boolean> info) {
+        if (!RenderVisibilityDecider.isArmorStandVisible()) {
+            info.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/java/dev/nozh/mixin/MixinEntityRenderDispatcher.java
+++ b/src/main/java/dev/nozh/mixin/MixinEntityRenderDispatcher.java
@@ -1,6 +1,6 @@
 package dev.nozh.mixin;
 
-import dev.nozh.core.settings.NozhRenderSettings;
+import dev.nozh.core.render.RenderVisibilityDecider;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.EntityRenderDispatcher;
 import net.minecraft.client.util.math.MatrixStack;
@@ -21,13 +21,13 @@ public class MixinEntityRenderDispatcher {
             CallbackInfo ci) {
 
         // Armor Stands
-        if (entity instanceof ArmorStandEntity && !NozhRenderSettings.isArmorStandsVisible()) {
+        if (entity instanceof ArmorStandEntity && !RenderVisibilityDecider.isArmorStandVisible()) {
             ci.cancel();
             return;
         }
 
         // Item Frames (and Glowing Item Frames which inherit)
-        if (entity instanceof ItemFrameEntity && !NozhRenderSettings.isItemFramesVisible()) {
+        if (entity instanceof ItemFrameEntity && !RenderVisibilityDecider.isItemFrameVisible()) {
             ci.cancel();
             return;
         }

--- a/src/main/java/dev/nozh/mixin/MixinGameRenderer.java
+++ b/src/main/java/dev/nozh/mixin/MixinGameRenderer.java
@@ -1,0 +1,17 @@
+package dev.nozh.mixin;
+
+import dev.nozh.core.render.RenderVisibilityDecider;
+import net.minecraft.client.render.GameRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GameRenderer.class)
+public class MixinGameRenderer {
+
+    @Inject(method = "render", at = @At("HEAD"))
+    private void nozh$recordFrame(float tickDelta, long startTime, boolean tick, CallbackInfo info) {
+        RenderVisibilityDecider.recordGameRendererFrame();
+    }
+}

--- a/src/main/java/dev/nozh/mixin/MixinItemFrameEntity.java
+++ b/src/main/java/dev/nozh/mixin/MixinItemFrameEntity.java
@@ -1,0 +1,19 @@
+package dev.nozh.mixin;
+
+import dev.nozh.core.render.RenderVisibilityDecider;
+import net.minecraft.entity.decoration.ItemFrameEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemFrameEntity.class)
+public class MixinItemFrameEntity {
+
+    @Inject(method = "isInvisible", at = @At("HEAD"), cancellable = true)
+    private void nozh$forceInvisible(CallbackInfoReturnable<Boolean> info) {
+        if (!RenderVisibilityDecider.isItemFrameVisible()) {
+            info.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/resources/nozh.mixins.json
+++ b/src/main/resources/nozh.mixins.json
@@ -10,6 +10,9 @@
         "MixinKeyboard",
         "MixinMouse",
         "MixinEntityRenderDispatcher",
+        "MixinGameRenderer",
+        "MixinArmorStandEntity",
+        "MixinItemFrameEntity",
         "MixinBlockEntityRenderDispatcher",
         "MixinClientChunkManager",
         "MixinParticleManager"

--- a/src/test/java/dev/nozh/core/render/RenderVisibilityDeciderTest.java
+++ b/src/test/java/dev/nozh/core/render/RenderVisibilityDeciderTest.java
@@ -1,0 +1,22 @@
+package dev.nozh.core.render;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RenderVisibilityDeciderTest {
+
+    @Test
+    void resolveVisibilityUsesSupplierValue() {
+        assertTrue(RenderVisibilityDecider.resolveVisibility(() -> true, "test-true"));
+        assertFalse(RenderVisibilityDecider.resolveVisibility(() -> false, "test-false"));
+    }
+
+    @Test
+    void resolveVisibilityFallsBackWhenSupplierThrows() {
+        assertTrue(RenderVisibilityDecider.resolveVisibility(() -> {
+            throw new IllegalStateException("boom");
+        }, "test-exception"));
+    }
+}


### PR DESCRIPTION
### Motivation
- The roadmap (`future.txt`) declares `MixinGameRenderer`, `MixinArmorStandEntity`, and `MixinItemFrameEntity` as critical mixins but the mixin config and code did not include implementations.
- Entity render culling previously referenced `NozhRenderSettings` directly which provides no runtime-safe fallback if something goes wrong.
- Add lightweight hooks to record renderer frames and to control visibility for armor stands and item frames to enable safe, reversible render optimizations. 
- Provide a minimal safety layer so rendering decisions never crash the client and fall back to visible behavior on errors.

### Description
- Added `dev.nozh.core.render.RenderVisibilityDecider` which centralizes visibility checks, logs one-time warnings, and provides safe fallbacks. 
- Implemented `MixinGameRenderer` to record renderer frames via `RenderVisibilityDecider.recordGameRendererFrame()`. 
- Added `MixinArmorStandEntity` and `MixinItemFrameEntity` which use `RenderVisibilityDecider` to force entities invisible when configured. 
- Updated `src/main/resources/nozh.mixins.json` and replaced direct `NozhRenderSettings` checks in `MixinEntityRenderDispatcher` with `RenderVisibilityDecider`, and added a minimal unit test `RenderVisibilityDeciderTest`.

### Testing
- Added unit test `dev.nozh.core.render.RenderVisibilityDeciderTest` which asserts normal supplier behavior and fallback-on-exception behavior. 
- Attempted to run `./gradlew test --tests dev.nozh.core.render.RenderVisibilityDeciderTest` but the Gradle wrapper download failed due to a network/proxy error, so tests could not be executed in CI here. 
- No other automated tests were executed in this environment. 
- Compilation and runtime verification should be performed in a network-enabled environment or CI to ensure mixins are applied as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2c3d5960832d89b732aab695c78b)