### PR TITLE
Clarify implemented vs planned roadmap status

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## v0.1.0 (Current) - " The Foundation"
 
-* **Status**: Released / RC
+* **Status**: Released / RC (IMPLEMENTADO)
 * **Features/Phases Completed**:
   * Phase 0-2: Safe architecture, atomic config, SafeMode.
   * Phase 3: Accurate P95 Frametime Profiler.
@@ -14,15 +14,17 @@
 
 > **Contract**: Closed phases (0–6.5) are considered architecturally frozen in v0.x releases. New functionality must extend the system, not rewrite it.
 
-## v0.2.0 - "The Analyst" (Planned)
+## v0.2.0 - "The Analyst" (Planificado)
 
+* **Status**: Planificado (NO implementado aún)
 * **Goal**: Distinguish CPU vs GPU bottlenecks accurately.
 * **Tech**: Tick Time measurements.
 * **Phase 4.5**: Implement TickTimeSampler (read-only initially - no actions).
 * **Phase 5 update**: Updated rules to target specific bottlenecks (e.g. reduce entities for CPU, render distance for GPU).
 
-## v0.3.0 - "The Executive" (Planned)
+## v0.3.0 - "The Executive" (Planificado)
 
+* **Status**: Planificado (NO implementado aún)
 * **Goal**: Expand the arsenal of actions.
 * **New Actions**:
   * `DECREASE_RENDER_DISTANCE` (with fog adjustment)

--- a/docs/critical-notes-for-beta.md
+++ b/docs/critical-notes-for-beta.md
@@ -2,7 +2,7 @@
 
 **Date:** 2025-12-31  
 **Author:** CTO Review Notes  
-**Status:** PRE-BETA WARNINGS
+**Status:** PRE-BETA WARNINGS (PLANIFICADO, NO IMPLEMENTADO)
 
 ---
 

--- a/docs/technical-debt-audit.md
+++ b/docs/technical-debt-audit.md
@@ -4,6 +4,11 @@
 **Version:** v0.2-alpha  
 **Status:** ZERO DEBT
 
+## Implementation Status (Explicit)
+
+- **Implemented (v0.1.x)**: Current shipped baseline, no new wiring beyond existing TODO placeholders.
+- **Planned (v0.2-beta)**: RuntimeState wiring, Chaos scenarios, and HUD integration TODOs listed below.
+
 ---
 
 ## TODOs Analysis (24 found)

--- a/future.txt
+++ b/future.txt
@@ -1,9 +1,9 @@
 # NOZH - FUTURE ROADMAP & IMPLEMENTATION GUIDE
 # THIS FILE IS GOLD - Complete optimization strategy
 # Updated: January 6, 2026
-# Status: PRIORITY 1 & 2 COMPLETED
+# Status: PRIORITY 1 IMPLEMENTED (v0.1) / PRIORITY 2-3 PLANNED (v0.2+)
 
-## 🎯 COMPLETED FEATURES (PRIORITY 1)
+## 🎯 IMPLEMENTADO (PRIORITY 1 / v0.1)
 
 ### ✅ 1. FEEDBACK LOOP COMPLETO
 - SessionLearning integrado y activo
@@ -32,7 +32,7 @@
 - StateStore actualizado en tiempo real
 - Governor responde a cambios inmediatos
 
-## 🛠️ EN DESARROLLO (PRIORITY 2)
+## 🛠️ PLANIFICADO (PRIORITY 2 / v0.2)
 
 ### 🔄 1. DETECCIÓN CPU vs GPU AVANZADA
 ```java
@@ -72,7 +72,7 @@
 - Status visible en HUD
 ```
 
-## 🚀 PLANEADO (PRIORITY 3 - PULIDO)
+## 🚀 PLANIFICADO (PRIORITY 3 / v0.3 - PULIDO)
 
 ### 1. ALGORITMO PREDICTIVO
 ```java
@@ -293,9 +293,10 @@ EXPLORING:
 
 ### Version Scheme:
 ```
-v0.2.0-beta  - Priority 1 completo
-v0.3.0-beta  - Priority 2 completo
-v1.0.0       - Priority 3 completo (RELEASE)
+v0.1.0        - Priority 1 completo (IMPLEMENTADO)
+v0.2.0-beta   - Priority 2 completo (PLANIFICADO)
+v0.3.0-beta   - Priority 3 completo (PLANIFICADO)
+v1.0.0        - Release estable (post Priority 3)
 ```
 
 ## 🎓 COMMUNITY


### PR DESCRIPTION
### Motivation
- Make explicit which features are implemented versus planned so docs do not contradict each other.  
- Ensure the v0.x version statuses (v0.1 / v0.2 / v0.3) are consistent across roadmap artifacts.  
- Surface integration work (RuntimeState wiring, chaos scenarios, HUD) as planned items rather than technical debt.  
- Reduce ambiguity for release planning and QA prior to `v0.2-beta` work.  

### Description
- Updated `future.txt` to label Priority 1 as `IMPLEMENTADO (v0.1)` and mark Priority 2/3 as `PLANIFICADO (v0.2+/v0.3)`, and adjusted the version scheme lines.  
- Modified `ROADMAP.md` to mark `v0.1` as implemented and add explicit `Status: Planificado (NO implementado aún)` lines for `v0.2` and `v0.3`.  
- Added an `Implementation Status (Explicit)` section to `docs/technical-debt-audit.md` clarifying which items are implemented vs planned.  
- Clarified the status line in `docs/critical-notes-for-beta.md` to indicate the notes are pre-beta and planned (not implemented).  

### Testing
- No automated tests were executed because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2e8051e0832d9cf81379adf7a64a)