### PR TITLE
Add hybrid governor with persisted decision-tree model and decision latency budget

### DIFF
--- a/src/main/java/dev/nozh/NozhConstants.java
+++ b/src/main/java/dev/nozh/NozhConstants.java
@@ -38,6 +38,8 @@ public final class NozhConstants {
     public static final Path CONFIG_FILE;
     public static final Path STATE_FILE;
     public static final Path STATE_TMP_FILE;
+    public static final Path MODEL_DIR;
+    public static final Path MODEL_FILE;
 
     static {
         Path configDir;
@@ -50,6 +52,8 @@ public final class NozhConstants {
         CONFIG_FILE = CONFIG_DIR.resolve("nozh.json");
         STATE_FILE = CONFIG_DIR.resolve("state.json");
         STATE_TMP_FILE = CONFIG_DIR.resolve("state.tmp");
+        MODEL_DIR = CONFIG_DIR.resolve("models");
+        MODEL_FILE = MODEL_DIR.resolve("hybrid_model_v1.json");
     }
 
     // Crash loop guard thresholds

--- a/src/main/java/dev/nozh/core/config/JsonMini.java
+++ b/src/main/java/dev/nozh/core/config/JsonMini.java
@@ -38,6 +38,7 @@ public final class JsonMini {
                 "  \"allowGameplayImpactActions\": " + c.allowGameplayImpactActions + ",\n" +
                 "  \"safeModeForce\": " + c.safeModeForce + ",\n" +
                 "  \"rollbackEnabled\": " + c.rollbackEnabled + ",\n" +
+                "  \"hybridModelEnabled\": " + c.hybridModelEnabled + ",\n" +
 
                 "  \"rollbackWindowMillis\": " + c.rollbackWindowMillis + ",\n" +
                 "  \"improvementEpsilonAvgMs\": " + c.improvementEpsilonAvgMs + ",\n" +
@@ -45,6 +46,8 @@ public final class JsonMini {
                 "  \"rollbackEvaluationTicks\": " + c.rollbackEvaluationTicks + ",\n" +
                 "  \"rollbackCooldownMillis\": " + c.rollbackCooldownMillis + ",\n" +
                 "  \"observationWindowSeconds\": " + c.observationWindowSeconds + ",\n" +
+                "  \"hybridModelBlockConfidence\": " + c.hybridModelBlockConfidence + ",\n" +
+                "  \"governorDecisionBudgetMs\": " + c.governorDecisionBudgetMs + ",\n" +
 
                 "  \"historyMaxEntries\": " + c.historyMaxEntries + ",\n" +
                 "  \"historyCommandLimit\": " + c.historyCommandLimit + ",\n" +
@@ -131,6 +134,7 @@ public final class JsonMini {
             c.allowGameplayImpactActions = getBool(json, "allowGameplayImpactActions", c.allowGameplayImpactActions);
             c.safeModeForce = getBool(json, "safeModeForce", c.safeModeForce);
             c.rollbackEnabled = getBool(json, "rollbackEnabled", c.rollbackEnabled);
+            c.hybridModelEnabled = getBool(json, "hybridModelEnabled", c.hybridModelEnabled);
 
             // Rollback Tuning
             c.rollbackWindowMillis = getInt(json, "rollbackWindowMillis", c.rollbackWindowMillis);
@@ -139,6 +143,9 @@ public final class JsonMini {
             c.rollbackEvaluationTicks = getInt(json, "rollbackEvaluationTicks", c.rollbackEvaluationTicks);
             c.rollbackCooldownMillis = getInt(json, "rollbackCooldownMillis", c.rollbackCooldownMillis);
             c.observationWindowSeconds = getInt(json, "observationWindowSeconds", c.observationWindowSeconds);
+            c.hybridModelBlockConfidence = getDouble(json, "hybridModelBlockConfidence",
+                    c.hybridModelBlockConfidence);
+            c.governorDecisionBudgetMs = getInt(json, "governorDecisionBudgetMs", c.governorDecisionBudgetMs);
 
             // Limits
             c.historyMaxEntries = getInt(json, "historyMaxEntries", c.historyMaxEntries);

--- a/src/main/java/dev/nozh/core/config/NozhConfig.java
+++ b/src/main/java/dev/nozh/core/config/NozhConfig.java
@@ -29,6 +29,7 @@ public class NozhConfig {
     public boolean allowGameplayImpactActions = false; // Phase 8: Level 2/3 actions
     public boolean safeModeForce = false;
     public boolean rollbackEnabled = true;
+    public boolean hybridModelEnabled = true;
 
     // Tuning Parameters (Rollback)
     public int rollbackWindowMillis = 45000;
@@ -37,6 +38,8 @@ public class NozhConfig {
     public int rollbackEvaluationTicks = 100;
     public int rollbackCooldownMillis = 60000;
     public int observationWindowSeconds = 5;
+    public double hybridModelBlockConfidence = 0.65;
+    public int governorDecisionBudgetMs = 8;
 
     // Performance Targets
     public int targetFps = 60;
@@ -136,6 +139,16 @@ public class NozhConfig {
         // observationWindowSeconds: 3-10
         if (observationWindowSeconds < 3 || observationWindowSeconds > 10) {
             observationWindowSeconds = clamp(observationWindowSeconds, 3, 10);
+            corrected = true;
+        }
+
+        if (hybridModelBlockConfidence < 0.0 || hybridModelBlockConfidence > 1.0) {
+            hybridModelBlockConfidence = clamp(hybridModelBlockConfidence, 0.0, 1.0);
+            corrected = true;
+        }
+
+        if (governorDecisionBudgetMs < 1 || governorDecisionBudgetMs > 50) {
+            governorDecisionBudgetMs = clamp(governorDecisionBudgetMs, 1, 50);
             corrected = true;
         }
 

--- a/src/main/java/dev/nozh/core/governor/DecisionFeatures.java
+++ b/src/main/java/dev/nozh/core/governor/DecisionFeatures.java
@@ -1,0 +1,29 @@
+package dev.nozh.core.governor;
+
+import dev.nozh.core.context.Scenario;
+
+public record DecisionFeatures(
+        double avgFrametimeMs,
+        double p95FrametimeMs,
+        int spikeCount,
+        String bound,
+        GovernorMode mode,
+        Scenario scenario) {
+
+    public double featureValue(String featureName) {
+        if (featureName == null) {
+            return 0.0;
+        }
+        return switch (featureName) {
+            case "avgFrametimeMs" -> avgFrametimeMs;
+            case "p95FrametimeMs" -> p95FrametimeMs;
+            case "spikeCount" -> spikeCount;
+            case "boundCpu" -> "CPU".equalsIgnoreCase(bound) ? 1.0 : 0.0;
+            case "boundGpu" -> "GPU".equalsIgnoreCase(bound) ? 1.0 : 0.0;
+            case "modeAggressive" -> mode == GovernorMode.AUTO_AGGRESSIVE ? 1.0 : 0.0;
+            case "modeConservative" -> mode == GovernorMode.AUTO_CONSERVATIVE ? 1.0 : 0.0;
+            case "scenarioCombat" -> scenario == Scenario.COMBAT ? 1.0 : 0.0;
+            default -> 0.0;
+        };
+    }
+}

--- a/src/main/java/dev/nozh/core/governor/DecisionTreeModel.java
+++ b/src/main/java/dev/nozh/core/governor/DecisionTreeModel.java
@@ -1,0 +1,143 @@
+package dev.nozh.core.governor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class DecisionTreeModel {
+
+    public enum DecisionLabel {
+        ALLOW,
+        BLOCK
+    }
+
+    public record ModelDecision(DecisionLabel label, double confidence) {
+    }
+
+    public record NodeSpec(
+            int id,
+            String feature,
+            double threshold,
+            Integer leftId,
+            Integer rightId,
+            DecisionLabel label,
+            double confidence) {
+
+        public boolean isLeaf() {
+            return label != null;
+        }
+    }
+
+    private sealed interface Node permits DecisionNode, LeafNode {
+        ModelDecision evaluate(DecisionFeatures features);
+    }
+
+    private static final class DecisionNode implements Node {
+        private final String feature;
+        private final double threshold;
+        private final Node left;
+        private final Node right;
+
+        private DecisionNode(String feature, double threshold, Node left, Node right) {
+            this.feature = feature;
+            this.threshold = threshold;
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public ModelDecision evaluate(DecisionFeatures features) {
+            double value = features.featureValue(feature);
+            return value <= threshold ? left.evaluate(features) : right.evaluate(features);
+        }
+    }
+
+    private static final class LeafNode implements Node {
+        private final ModelDecision decision;
+
+        private LeafNode(ModelDecision decision) {
+            this.decision = decision;
+        }
+
+        @Override
+        public ModelDecision evaluate(DecisionFeatures features) {
+            return decision;
+        }
+    }
+
+    private final int modelVersion;
+    private final String trainedAt;
+    private final int rootId;
+    private final Map<Integer, NodeSpec> nodeSpecs;
+    private final Node root;
+
+    private DecisionTreeModel(int modelVersion, String trainedAt, int rootId, Map<Integer, NodeSpec> nodeSpecs, Node root) {
+        this.modelVersion = modelVersion;
+        this.trainedAt = trainedAt;
+        this.rootId = rootId;
+        this.nodeSpecs = nodeSpecs;
+        this.root = root;
+    }
+
+    public static DecisionTreeModel fromSpecs(int modelVersion, String trainedAt, int rootId, List<NodeSpec> specs) {
+        Objects.requireNonNull(specs, "specs");
+        Map<Integer, NodeSpec> specMap = new HashMap<>();
+        for (NodeSpec spec : specs) {
+            specMap.put(spec.id(), spec);
+        }
+        Node root = buildNode(rootId, specMap, new ArrayList<>());
+        if (root == null) {
+            return null;
+        }
+        return new DecisionTreeModel(modelVersion, trainedAt, rootId, specMap, root);
+    }
+
+    private static Node buildNode(int nodeId, Map<Integer, NodeSpec> specMap, List<Integer> visited) {
+        if (visited.contains(nodeId)) {
+            return null;
+        }
+        NodeSpec spec = specMap.get(nodeId);
+        if (spec == null) {
+            return null;
+        }
+        if (spec.isLeaf()) {
+            return new LeafNode(new ModelDecision(spec.label(), spec.confidence()));
+        }
+        if (spec.leftId() == null || spec.rightId() == null || spec.feature() == null) {
+            return null;
+        }
+        visited.add(nodeId);
+        Node left = buildNode(spec.leftId(), specMap, visited);
+        Node right = buildNode(spec.rightId(), specMap, visited);
+        visited.remove(visited.size() - 1);
+        if (left == null || right == null) {
+            return null;
+        }
+        return new DecisionNode(spec.feature(), spec.threshold(), left, right);
+    }
+
+    public ModelDecision evaluate(DecisionFeatures features) {
+        return root.evaluate(features);
+    }
+
+    public int modelVersion() {
+        return modelVersion;
+    }
+
+    public String trainedAt() {
+        return trainedAt;
+    }
+
+    public int rootId() {
+        return rootId;
+    }
+
+    public List<NodeSpec> nodeSpecs() {
+        List<NodeSpec> specs = new ArrayList<>(nodeSpecs.values());
+        specs.sort((a, b) -> Integer.compare(a.id(), b.id()));
+        return Collections.unmodifiableList(specs);
+    }
+}

--- a/src/main/java/dev/nozh/core/governor/DecisionTreeModelJson.java
+++ b/src/main/java/dev/nozh/core/governor/DecisionTreeModelJson.java
@@ -1,0 +1,144 @@
+package dev.nozh.core.governor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DecisionTreeModelJson {
+
+    private DecisionTreeModelJson() {
+    }
+
+    public static DecisionTreeModel fromJson(String json) {
+        if (json == null || json.isBlank()) {
+            return null;
+        }
+        int version = getInt(json, "modelVersion", -1);
+        int rootId = getInt(json, "rootId", -1);
+        String trainedAt = getString(json, "trainedAt", "");
+        if (version <= 0 || rootId < 0) {
+            return null;
+        }
+        String nodesBlock = getArrayBlock(json, "nodes");
+        if (nodesBlock == null) {
+            return null;
+        }
+        List<DecisionTreeModel.NodeSpec> specs = parseNodes(nodesBlock);
+        if (specs.isEmpty()) {
+            return null;
+        }
+        return DecisionTreeModel.fromSpecs(version, trainedAt, rootId, specs);
+    }
+
+    public static String toJson(DecisionTreeModel model) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"modelVersion\": ").append(model.modelVersion()).append(",\n");
+        sb.append("  \"trainedAt\": \"").append(model.trainedAt()).append("\",\n");
+        sb.append("  \"modelType\": \"decision_tree\",\n");
+        sb.append("  \"rootId\": ").append(model.rootId()).append(",\n");
+        sb.append("  \"nodes\": [\n");
+        List<DecisionTreeModel.NodeSpec> specs = model.nodeSpecs();
+        for (int i = 0; i < specs.size(); i++) {
+            DecisionTreeModel.NodeSpec spec = specs.get(i);
+            sb.append("    {");
+            sb.append("\"id\": ").append(spec.id());
+            if (spec.isLeaf()) {
+                sb.append(", \"label\": \"").append(spec.label().name()).append("\"");
+                sb.append(", \"confidence\": ").append(spec.confidence());
+            } else {
+                sb.append(", \"feature\": \"").append(spec.feature()).append("\"");
+                sb.append(", \"threshold\": ").append(spec.threshold());
+                sb.append(", \"left\": ").append(spec.leftId());
+                sb.append(", \"right\": ").append(spec.rightId());
+            }
+            sb.append("}");
+            if (i < specs.size() - 1) {
+                sb.append(",");
+            }
+            sb.append("\n");
+        }
+        sb.append("  ]\n");
+        sb.append("}\n");
+        return sb.toString();
+    }
+
+    private static List<DecisionTreeModel.NodeSpec> parseNodes(String nodesBlock) {
+        List<DecisionTreeModel.NodeSpec> specs = new ArrayList<>();
+        Pattern nodePattern = Pattern.compile("\\{([^{}]+)\\}");
+        Matcher matcher = nodePattern.matcher(nodesBlock);
+        while (matcher.find()) {
+            String nodeJson = matcher.group(1);
+            int id = getInt(nodeJson, "id", -1);
+            if (id < 0) {
+                continue;
+            }
+            String label = getString(nodeJson, "label", null);
+            if (label != null) {
+                double confidence = getDouble(nodeJson, "confidence", 0.0);
+                DecisionTreeModel.DecisionLabel decisionLabel;
+                try {
+                    decisionLabel = DecisionTreeModel.DecisionLabel.valueOf(label);
+                } catch (IllegalArgumentException ex) {
+                    continue;
+                }
+                specs.add(new DecisionTreeModel.NodeSpec(id, null, 0.0, null, null, decisionLabel, confidence));
+            } else {
+                String feature = getString(nodeJson, "feature", null);
+                double threshold = getDouble(nodeJson, "threshold", Double.NaN);
+                int left = getInt(nodeJson, "left", -1);
+                int right = getInt(nodeJson, "right", -1);
+                if (feature == null || !Double.isFinite(threshold) || left < 0 || right < 0) {
+                    continue;
+                }
+                specs.add(new DecisionTreeModel.NodeSpec(id, feature, threshold, left, right, null, 0.0));
+            }
+        }
+        return specs;
+    }
+
+    private static String getArrayBlock(String json, String key) {
+        Pattern p = Pattern.compile("\\\"" + key + "\\\"\\s*:\\s*\\[(.*?)]", Pattern.DOTALL);
+        Matcher m = p.matcher(json);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    private static int getInt(String json, String key, int def) {
+        Pattern p = Pattern.compile("\\\"" + key + "\\\"\\s*:\\s*(-?\\d+)");
+        Matcher m = p.matcher(json);
+        if (m.find()) {
+            try {
+                return Integer.parseInt(m.group(1));
+            } catch (NumberFormatException e) {
+                return def;
+            }
+        }
+        return def;
+    }
+
+    private static double getDouble(String json, String key, double def) {
+        Pattern p = Pattern.compile("\\\"" + key + "\\\"\\s*:\\s*(-?\\d+(?:\\.\\d+)?)");
+        Matcher m = p.matcher(json);
+        if (m.find()) {
+            try {
+                return Double.parseDouble(m.group(1));
+            } catch (NumberFormatException e) {
+                return def;
+            }
+        }
+        return def;
+    }
+
+    private static String getString(String json, String key, String def) {
+        Pattern p = Pattern.compile("\\\"" + key + "\\\"\\s*:\\s*\\\"([^\\\"]*)\\\"");
+        Matcher m = p.matcher(json);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return def;
+    }
+}

--- a/src/main/java/dev/nozh/core/governor/DecisionTreeModelStore.java
+++ b/src/main/java/dev/nozh/core/governor/DecisionTreeModelStore.java
@@ -1,0 +1,101 @@
+package dev.nozh.core.governor;
+
+import dev.nozh.NozhConstants;
+import dev.nozh.core.NozhLogger;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public final class DecisionTreeModelStore {
+
+    private static final int CURRENT_VERSION = 1;
+    private final NozhLogger logger;
+    private final Path modelDir;
+    private final Path modelFile;
+    private DecisionTreeModel cached;
+
+    public DecisionTreeModelStore(NozhLogger logger) {
+        this(logger, NozhConstants.MODEL_DIR, NozhConstants.MODEL_FILE);
+    }
+
+    DecisionTreeModelStore(NozhLogger logger, Path modelDir, Path modelFile) {
+        this.logger = logger;
+        this.modelDir = modelDir;
+        this.modelFile = modelFile;
+    }
+
+    public Optional<DecisionTreeModel> loadModel() {
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+        DecisionTreeModel loaded = readModel();
+        if (loaded != null) {
+            cached = loaded;
+            return Optional.of(loaded);
+        }
+        if (ensureDefaultModel()) {
+            cached = readModel();
+            if (cached != null) {
+                return Optional.of(cached);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private DecisionTreeModel readModel() {
+        try {
+            if (!Files.exists(modelFile)) {
+                return null;
+            }
+            String json = Files.readString(modelFile, StandardCharsets.UTF_8);
+            DecisionTreeModel model = DecisionTreeModelJson.fromJson(json);
+            if (model == null) {
+                logger.warn("Hybrid model parse failed, falling back to rules");
+                return null;
+            }
+            if (model.modelVersion() != CURRENT_VERSION) {
+                logger.warn("Hybrid model version mismatch (expected %d got %d), falling back to rules",
+                        CURRENT_VERSION, model.modelVersion());
+                return null;
+            }
+            return model;
+        } catch (Exception e) {
+            logger.warn("Hybrid model read failed, falling back to rules: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private boolean ensureDefaultModel() {
+        try {
+            Files.createDirectories(modelDir);
+            if (Files.exists(modelFile)) {
+                return true;
+            }
+            DecisionTreeModel model = defaultModel();
+            String json = DecisionTreeModelJson.toJson(model);
+            Files.writeString(modelFile, json, StandardCharsets.UTF_8);
+            logger.info("Hybrid model default persisted at " + modelFile);
+            return true;
+        } catch (Exception e) {
+            logger.warn("Failed to persist hybrid model default: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private DecisionTreeModel defaultModel() {
+        List<DecisionTreeModel.NodeSpec> specs = List.of(
+                new DecisionTreeModel.NodeSpec(0, "p95FrametimeMs", 20.0, 1, 2, null, 0.0),
+                new DecisionTreeModel.NodeSpec(1, "spikeCount", 2.0, 3, 4, null, 0.0),
+                new DecisionTreeModel.NodeSpec(2, null, 0.0, null, null,
+                        DecisionTreeModel.DecisionLabel.BLOCK, 0.72),
+                new DecisionTreeModel.NodeSpec(3, null, 0.0, null, null,
+                        DecisionTreeModel.DecisionLabel.ALLOW, 0.78),
+                new DecisionTreeModel.NodeSpec(4, null, 0.0, null, null,
+                        DecisionTreeModel.DecisionLabel.BLOCK, 0.63));
+        return DecisionTreeModel.fromSpecs(CURRENT_VERSION, Instant.now().toString(), 0, specs);
+    }
+}

--- a/src/main/java/dev/nozh/core/governor/GovernorRunner.java
+++ b/src/main/java/dev/nozh/core/governor/GovernorRunner.java
@@ -44,7 +44,7 @@ public final class GovernorRunner {
     private static final int REVERSE_IMPROVEMENT_STREAK = 3;
     private static final long SPIKE_PREDICTION_MIN_WINDOW_MS = 5_000L;
 
-    private final SimulationGovernor governor;
+    private final HybridGovernor governor;
     private final ActionBus actionBus;
     private final NozhLogger logger;
     private final StateStore stateStore;
@@ -89,7 +89,7 @@ public final class GovernorRunner {
                 sessionLearning,
                 new CompatibilityMatrix());
 
-        this.governor = new SimulationGovernor(matrix);
+        this.governor = new HybridGovernor(matrix, logger);
         this.actionBus = actionBus;
         this.stateStore = stateStore;
         this.logger = logger;
@@ -196,6 +196,7 @@ public final class GovernorRunner {
             return;
         }
 
+        long decisionStartNanos = perfManager != null ? perfManager.startDecisionTimer() : System.nanoTime();
         Optional<ActionCandidate> decisionOpt = governor.decide(
                 state,
                 mode,
@@ -206,7 +207,16 @@ public final class GovernorRunner {
                 config.reverseEpsilonMs,
                 reverseReady,
                 state.baselineSnapshot(),
-                state.currentSettings());
+                state.currentSettings(),
+                config);
+
+        if (perfManager != null && !perfManager.isDecisionWithinBudget(decisionStartNanos,
+                config.governorDecisionBudgetMs)) {
+            logger.warn(String.format(
+                    "Governor decision aborted - latency budget exceeded (%dms)",
+                    perfManager.getLastDecisionLatencyMs()));
+            return;
+        }
 
         if (decisionOpt.isEmpty()) {
             return;

--- a/src/main/java/dev/nozh/core/governor/HybridGovernor.java
+++ b/src/main/java/dev/nozh/core/governor/HybridGovernor.java
@@ -1,0 +1,89 @@
+package dev.nozh.core.governor;
+
+import dev.nozh.core.NozhLogger;
+import dev.nozh.core.config.NozhConfig;
+import dev.nozh.core.matrix.ActionCandidate;
+import dev.nozh.core.matrix.ActionMatrix;
+import dev.nozh.core.state.RuntimeState;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class HybridGovernor {
+
+    private final SimulationGovernor rulesGovernor;
+    private final DecisionTreeModelStore modelStore;
+    private final NozhLogger logger;
+
+    public HybridGovernor(ActionMatrix actionMatrix, NozhLogger logger) {
+        this.rulesGovernor = new SimulationGovernor(actionMatrix);
+        this.modelStore = new DecisionTreeModelStore(logger);
+        this.logger = logger;
+    }
+
+    public Optional<ActionCandidate> decide(
+            RuntimeState state,
+            GovernorMode mode,
+            String currentBound,
+            long nowMillis,
+            OptimizationProfile profile,
+            int targetFps,
+            double reverseEpsilonMs,
+            boolean reverseReady,
+            dev.nozh.core.state.BaselineSnapshot baselineSnapshot,
+            Map<dev.nozh.core.bus.CapabilityId, dev.nozh.core.bus.CapabilityValue> currentSettings,
+            NozhConfig config) {
+        Optional<ActionCandidate> candidate = rulesGovernor.decide(
+                state,
+                mode,
+                currentBound,
+                nowMillis,
+                profile,
+                targetFps,
+                reverseEpsilonMs,
+                reverseReady,
+                baselineSnapshot,
+                currentSettings);
+        if (candidate.isEmpty()) {
+            return candidate;
+        }
+        if (config == null || !config.hybridModelEnabled) {
+            return candidate;
+        }
+        Optional<DecisionTreeModel> modelOpt = modelStore.loadModel();
+        if (modelOpt.isEmpty()) {
+            return candidate;
+        }
+        DecisionTreeModel model = modelOpt.get();
+        DecisionFeatures features = new DecisionFeatures(
+                state.avgFrametimeMs(),
+                state.p95FrametimeMs(),
+                state.spikeCount(),
+                currentBound,
+                mode,
+                state.currentScenario());
+        DecisionTreeModel.ModelDecision decision = model.evaluate(features);
+        if (decision.label() == DecisionTreeModel.DecisionLabel.BLOCK
+                && decision.confidence() >= config.hybridModelBlockConfidence) {
+            logger.debug(String.format(
+                    "Hybrid model blocked action (confidence=%.2f)",
+                    decision.confidence()));
+            return Optional.empty();
+        }
+        return candidate;
+    }
+
+    public boolean canAct(RuntimeState state, long lastActionTimestamp, long nowMillis, boolean benchmarkMode,
+            long benchmarkIntervalMillis) {
+        return rulesGovernor.canAct(state, lastActionTimestamp, nowMillis, benchmarkMode, benchmarkIntervalMillis);
+    }
+
+    public long getObservationWindow(RuntimeState state) {
+        return rulesGovernor.getObservationWindow(state);
+    }
+
+    public ActionOutcome evaluateOutcome(dev.nozh.api.PerfSnapshot previousSnapshot,
+            dev.nozh.api.PerfSnapshot newSnapshot) {
+        return rulesGovernor.evaluateOutcome(previousSnapshot, newSnapshot);
+    }
+}

--- a/src/main/java/dev/nozh/core/profiler/DecisionLatencyEvaluator.java
+++ b/src/main/java/dev/nozh/core/profiler/DecisionLatencyEvaluator.java
@@ -1,0 +1,23 @@
+package dev.nozh.core.profiler;
+
+import java.util.concurrent.TimeUnit;
+
+public final class DecisionLatencyEvaluator {
+
+    private long lastDecisionLatencyMs = -1L;
+
+    public long startTimer() {
+        return System.nanoTime();
+    }
+
+    public boolean isWithinBudget(long startNanos, int budgetMs) {
+        long elapsedNanos = System.nanoTime() - startNanos;
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+        lastDecisionLatencyMs = elapsedMs;
+        return elapsedMs <= budgetMs;
+    }
+
+    public long getLastDecisionLatencyMs() {
+        return lastDecisionLatencyMs;
+    }
+}

--- a/src/main/java/dev/nozh/core/profiler/PerfManager.java
+++ b/src/main/java/dev/nozh/core/profiler/PerfManager.java
@@ -30,6 +30,7 @@ public class PerfManager {
     private int windowSeconds;
     private final PerfWindowController windowController;
     private final SpikeTrendPredictor spikePredictor;
+    private final DecisionLatencyEvaluator decisionLatencyEvaluator;
     private long lastWindowAdjustMillis = 0L;
 
     public PerfManager() {
@@ -38,6 +39,7 @@ public class PerfManager {
         this.windowSeconds = 5; // Default window
         this.windowController = new PerfWindowController(3, 10);
         this.spikePredictor = new SpikeTrendPredictor();
+        this.decisionLatencyEvaluator = new DecisionLatencyEvaluator();
 
         int targetFps = Math.max(30, config.targetFps);
         int capacity = calculateCapacity(targetFps, windowSeconds);
@@ -105,6 +107,18 @@ public class PerfManager {
 
     public SpikePrediction getSpikePrediction() {
         return spikePredictor.getLastPrediction();
+    }
+
+    public long startDecisionTimer() {
+        return decisionLatencyEvaluator.startTimer();
+    }
+
+    public boolean isDecisionWithinBudget(long startNanos, int budgetMs) {
+        return decisionLatencyEvaluator.isWithinBudget(startNanos, budgetMs);
+    }
+
+    public long getLastDecisionLatencyMs() {
+        return decisionLatencyEvaluator.getLastDecisionLatencyMs();
     }
 
     private void adjustWindowIfNeeded(PerfSnapshot snapshot) {

--- a/src/test/java/dev/nozh/core/governor/DecisionTreeModelDeterminismTest.java
+++ b/src/test/java/dev/nozh/core/governor/DecisionTreeModelDeterminismTest.java
@@ -1,0 +1,46 @@
+package dev.nozh.core.governor;
+
+import dev.nozh.core.context.Scenario;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class DecisionTreeModelDeterminismTest {
+
+    @Test
+    void evaluationIsDeterministic() {
+        DecisionTreeModel model = DecisionTreeModel.fromSpecs(
+                1,
+                "2025-01-15T00:00:00Z",
+                0,
+                List.of(
+                        new DecisionTreeModel.NodeSpec(0, "p95FrametimeMs", 20.0, 1, 2, null, 0.0),
+                        new DecisionTreeModel.NodeSpec(1, "spikeCount", 2.0, 3, 4, null, 0.0),
+                        new DecisionTreeModel.NodeSpec(2, null, 0.0, null, null,
+                                DecisionTreeModel.DecisionLabel.BLOCK, 0.72),
+                        new DecisionTreeModel.NodeSpec(3, null, 0.0, null, null,
+                                DecisionTreeModel.DecisionLabel.ALLOW, 0.78),
+                        new DecisionTreeModel.NodeSpec(4, null, 0.0, null, null,
+                                DecisionTreeModel.DecisionLabel.BLOCK, 0.63)));
+
+        assertNotNull(model);
+
+        DecisionFeatures features = new DecisionFeatures(
+                16.0,
+                18.0,
+                1,
+                "GPU",
+                GovernorMode.AUTO_CONSERVATIVE,
+                Scenario.EXPLORING);
+
+        DecisionTreeModel.ModelDecision first = model.evaluate(features);
+        for (int i = 0; i < 10; i++) {
+            DecisionTreeModel.ModelDecision next = model.evaluate(features);
+            assertEquals(first.label(), next.label());
+            assertEquals(first.confidence(), next.confidence(), 0.0001);
+        }
+    }
+}

--- a/src/test/java/dev/nozh/core/profiler/PerfManagerLatencyBudgetTest.java
+++ b/src/test/java/dev/nozh/core/profiler/PerfManagerLatencyBudgetTest.java
@@ -1,0 +1,23 @@
+package dev.nozh.core.profiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PerfManagerLatencyBudgetTest {
+
+    @Test
+    void decisionLatencyBudgetStopsOverruns() {
+        PerfManager manager = new PerfManager();
+
+        long start = manager.startDecisionTimer();
+        long forcedStart = start - TimeUnit.MILLISECONDS.toNanos(12);
+        assertFalse(manager.isDecisionWithinBudget(forcedStart, 5));
+
+        long freshStart = manager.startDecisionTimer();
+        assertTrue(manager.isDecisionWithinBudget(freshStart, 50));
+    }
+}


### PR DESCRIPTION
### Motivation
- Combine existing deterministic rule-based governor with a lightweight learned classifier so runtime telemetry can block risky actions while preserving safe rule fallback.
- Ensure governor decisions remain low-latency and abort if the decision computation exceeds a small, configurable ms budget.
- Persist and version the hybrid model on disk under the config tree to allow safe rollout and reproducible behavior.
- Provide unit tests to guarantee deterministic model evaluation and to validate the latency budgeting behavior.

### Description
- Introduce a `DecisionTreeModel` and `DecisionTreeModelJson` parser with a `DecisionTreeModelStore` that loads/creates a default model under `NozhConstants.MODEL_DIR` / `MODEL_FILE` and falls back to rules on parse/version errors.
- Add `HybridGovernor` which wraps the existing `SimulationGovernor` and consults the persisted tree to optionally block candidates, and swap `SimulationGovernor` for `HybridGovernor` in `GovernorRunner`.
- Add decision-latency tracking via `DecisionLatencyEvaluator` and expose `startDecisionTimer` / `isDecisionWithinBudget` / `getLastDecisionLatencyMs` in `PerfManager`, and abort governor decisions that exceed `NozhConfig.governorDecisionBudgetMs`.
- Add config fields (`hybridModelEnabled`, `hybridModelBlockConfidence`, `governorDecisionBudgetMs`) and update `JsonMini`/`NozhConfig` validation, plus unit tests `DecisionTreeModelDeterminismTest` and `PerfManagerLatencyBudgetTest`.

### Testing
- Added `DecisionTreeModelDeterminismTest` which asserts repeated evaluations of the same features produce identical decisions; test was added but not executed here.
- Added `PerfManagerLatencyBudgetTest` which verifies the `DecisionLatencyEvaluator` correctly flags over-budget decisions; test was added but not executed here.
- No automated test suite was run as part of this change packaging (no runtime test execution was requested).
- Manual safeguards are in place: the model store creates a default persisted model and the hybrid path falls back to deterministic rules on parse/version errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3e8d9e6c832da47a7d32f961b02e)