### PR TITLE
Add automated modpack quick-test runner, Gradle task, and docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,29 @@ test {
 	maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
+tasks.register('quickTest', JavaExec) {
+	group = 'verification'
+	description = 'Runs the modpack quick-test executor and writes JSON/CSV results.'
+	classpath = sourceSets.test.runtimeClasspath
+	mainClass = 'dev.nozh.core.testing.ModpackQuickTestRunner'
+	dependsOn testClasses
+
+	def addArg = { prop, flag ->
+		if (project.hasProperty(prop)) {
+			args flag, project.property(prop).toString()
+		}
+	}
+
+	addArg('modpack', '--modpack')
+	addArg('seed', '--seed')
+	addArg('scenarios', '--scenarios')
+	addArg('outputDir', '--output')
+	addArg('samplesDir', '--samples')
+	addArg('warmupSeconds', '--warmup')
+	addArg('measurementSeconds', '--measurement')
+	addArg('cooldownSeconds', '--cooldown')
+}
+
 java {
 	sourceCompatibility = JavaVersion.VERSION_17
 	targetCompatibility = JavaVersion.VERSION_17

--- a/docs/automated-quick-test.md
+++ b/docs/automated-quick-test.md
@@ -1,0 +1,107 @@
+# Automated Modpack Quick Test Runner
+
+This guide explains how to run the automated quick-test executor and how to
+prepare large modpacks (Better Minecraft, ATM9) for consistent runs.
+
+## What the runner does
+
+The runner translates `docs/modpack-quick-test.md` into reproducible steps with
+teleports, actions, and fixed durations. It outputs:
+
+- `quick-test-plan.json` (scenario steps + timing windows)
+- `quick-test-results.json` (metadata + P95/P99 stats)
+- `quick-test-results.csv` (table format from `docs/benchmarking.md`)
+
+## Running the Gradle task
+
+From the repo root:
+
+```bash
+./gradlew quickTest \
+  -Pmodpack="Better Minecraft" \
+  -Pseed=123456789 \
+  -Pscenarios=mobs,mining,nether,rain \
+  -PoutputDir=build/test-results/quick-test \
+  -PsamplesDir=/path/to/frametime-samples
+```
+
+Optional timing overrides:
+
+```bash
+./gradlew quickTest -PwarmupSeconds=60 -PmeasurementSeconds=180 -PcooldownSeconds=30
+```
+
+### Scenario list
+
+Available scenario IDs (defaults to all):
+
+- `mobs`
+- `mining`
+- `nether`
+- `rain`
+
+## Providing frametime samples
+
+The executor computes P95/P99 from sample files. Place one file per scenario in
+`-PsamplesDir`, using either `.csv` or `.txt`:
+
+```
+/path/to/frametime-samples/
+  mobs.csv
+  mining.csv
+  nether.csv
+  rain.csv
+```
+
+Each file can contain one number per line or comma/space-separated values:
+
+```
+13.4, 15.2, 11.9
+14.1
+```
+
+If no samples are provided, the runner emits the plan and placeholder results
+with notes explaining what is missing.
+
+## Environment metadata
+
+Provide hardware and environment metadata via environment variables so the
+JSON/CSV outputs follow `docs/benchmarking.md`:
+
+```
+export NOZH_CPU="Ryzen 7 7800X3D"
+export NOZH_GPU="RTX 4070"
+export NOZH_RAM="32GB DDR5"
+export NOZH_DISPLAY="2560x1440 @ 144Hz"
+export NOZH_RENDERER="Sodium 0.5.3"
+export NOZH_SHADERS="Complementary 4.0"
+export NOZH_POWER_MODE="High Performance"
+export NOZH_BACKGROUND_LOAD="Discord + OBS"
+export NOZH_MC_VERSION="1.20.1"
+```
+
+## Runner setup for large modpacks
+
+### Better Minecraft
+
+- Use a dedicated launcher profile with **clean configs**.
+- Allocate **8–10 GB RAM** (avoid auto-managed allocation).
+- Disable shader packs until baseline data is captured.
+- Use render distance **12–16** and simulation distance **8–12**.
+- Pre-generate a world with the target seed, and note teleport coords for each
+  scenario area (mob farm, cave, nether biome, rain view).
+
+### All The Mods 9 (ATM9)
+
+- Use a dedicated profile and **fresh world** for consistent chunk state.
+- Allocate **10–12 GB RAM** and avoid background downloads/updates.
+- Confirm that chunk pre-generation is complete before running scenarios.
+- Capture the same scenario coordinates in a shared runbook so each run uses the
+  exact teleport location.
+
+## Suggested workflow
+
+1. Launch the modpack with the target seed.
+2. Gather scenario coordinates and update your local runbook.
+3. Record frametime samples while executing each scenario.
+4. Run `./gradlew quickTest` with `-PsamplesDir` to generate JSON/CSV output.

--- a/src/test/java/dev/nozh/core/testing/BenchmarkResult.java
+++ b/src/test/java/dev/nozh/core/testing/BenchmarkResult.java
@@ -1,0 +1,64 @@
+package dev.nozh.core.testing;
+
+public final class BenchmarkResult {
+    private final String scenarioId;
+    private final String scenarioName;
+    private final double averageMs;
+    private final double p95Ms;
+    private final Double p99Ms;
+    private final long spikeCount;
+    private final int sampleCount;
+    private final String notes;
+
+    public BenchmarkResult(
+        String scenarioId,
+        String scenarioName,
+        double averageMs,
+        double p95Ms,
+        Double p99Ms,
+        long spikeCount,
+        int sampleCount,
+        String notes
+    ) {
+        this.scenarioId = scenarioId;
+        this.scenarioName = scenarioName;
+        this.averageMs = averageMs;
+        this.p95Ms = p95Ms;
+        this.p99Ms = p99Ms;
+        this.spikeCount = spikeCount;
+        this.sampleCount = sampleCount;
+        this.notes = notes;
+    }
+
+    public String getScenarioId() {
+        return scenarioId;
+    }
+
+    public String getScenarioName() {
+        return scenarioName;
+    }
+
+    public double getAverageMs() {
+        return averageMs;
+    }
+
+    public double getP95Ms() {
+        return p95Ms;
+    }
+
+    public Double getP99Ms() {
+        return p99Ms;
+    }
+
+    public long getSpikeCount() {
+        return spikeCount;
+    }
+
+    public int getSampleCount() {
+        return sampleCount;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+}

--- a/src/test/java/dev/nozh/core/testing/EnvironmentMetadata.java
+++ b/src/test/java/dev/nozh/core/testing/EnvironmentMetadata.java
@@ -1,0 +1,34 @@
+package dev.nozh.core.testing;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class EnvironmentMetadata {
+    private final Map<String, String> values;
+
+    private EnvironmentMetadata(Map<String, String> values) {
+        this.values = Map.copyOf(values);
+    }
+
+    public static EnvironmentMetadata fromSystem(Map<String, String> env) {
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("cpu", env.getOrDefault("NOZH_CPU", "unknown"));
+        values.put("gpu", env.getOrDefault("NOZH_GPU", "unknown"));
+        values.put("ram", env.getOrDefault("NOZH_RAM", "unknown"));
+        values.put("os", env.getOrDefault("NOZH_OS", System.getProperty("os.name", "unknown")));
+        values.put("os_arch", System.getProperty("os.arch", "unknown"));
+        values.put("java", env.getOrDefault("NOZH_JVM", System.getProperty("java.version", "unknown")));
+        values.put("mc_version", env.getOrDefault("NOZH_MC_VERSION", "unknown"));
+        values.put("display", env.getOrDefault("NOZH_DISPLAY", "unknown"));
+        values.put("renderer", env.getOrDefault("NOZH_RENDERER", "unknown"));
+        values.put("shaders", env.getOrDefault("NOZH_SHADERS", "unknown"));
+        values.put("power_mode", env.getOrDefault("NOZH_POWER_MODE", "unknown"));
+        values.put("background_load", env.getOrDefault("NOZH_BACKGROUND_LOAD", "unknown"));
+        values.put("notes", env.getOrDefault("NOZH_ENV_NOTES", ""));
+        return new EnvironmentMetadata(values);
+    }
+
+    public Map<String, String> getValues() {
+        return values;
+    }
+}

--- a/src/test/java/dev/nozh/core/testing/FrametimeStats.java
+++ b/src/test/java/dev/nozh/core/testing/FrametimeStats.java
@@ -1,0 +1,44 @@
+package dev.nozh.core.testing;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class FrametimeStats {
+    private FrametimeStats() {
+    }
+
+    public static StatsResult compute(List<Double> samples) {
+        if (samples.isEmpty()) {
+            return new StatsResult(Double.NaN, Double.NaN, Double.NaN, 0, 0, false);
+        }
+        List<Double> sorted = new ArrayList<>(samples);
+        Collections.sort(sorted);
+        double avg = sorted.stream().mapToDouble(Double::doubleValue).average().orElse(Double.NaN);
+        double p95 = percentile(sorted, 0.95);
+        boolean p99Valid = sorted.size() >= 2000;
+        double p99 = p99Valid ? percentile(sorted, 0.99) : Double.NaN;
+        long spikes = sorted.stream().filter(value -> value > 500).count();
+        return new StatsResult(avg, p95, p99, spikes, sorted.size(), p99Valid);
+    }
+
+    private static double percentile(List<Double> sorted, double percentile) {
+        if (sorted.isEmpty()) {
+            return Double.NaN;
+        }
+        double rank = percentile * sorted.size();
+        int index = (int) Math.ceil(rank) - 1;
+        index = Math.max(0, Math.min(index, sorted.size() - 1));
+        return sorted.get(index);
+    }
+
+    public record StatsResult(
+        double averageMs,
+        double p95Ms,
+        double p99Ms,
+        long spikeCount,
+        int sampleCount,
+        boolean p99Valid
+    ) {
+    }
+}

--- a/src/test/java/dev/nozh/core/testing/ModpackQuickTestRunner.java
+++ b/src/test/java/dev/nozh/core/testing/ModpackQuickTestRunner.java
@@ -1,0 +1,198 @@
+package dev.nozh.core.testing;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public final class ModpackQuickTestRunner {
+    private static final int DEFAULT_WARMUP_SECONDS = 60;
+    private static final int DEFAULT_MEASUREMENT_SECONDS = 180;
+    private static final int DEFAULT_COOLDOWN_SECONDS = 30;
+
+    private ModpackQuickTestRunner() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        Map<String, String> arguments = parseArgs(args);
+        String modpack = arguments.getOrDefault("modpack", "unknown");
+        String seed = arguments.getOrDefault("seed", "unknown");
+        String outputDir = arguments.getOrDefault("output", "build/test-results/quick-test");
+        String sampleDir = arguments.get("samples");
+        int warmupSeconds = parseInt(arguments.get("warmupSeconds"), DEFAULT_WARMUP_SECONDS);
+        int measurementSeconds = parseInt(arguments.get("measurementSeconds"), DEFAULT_MEASUREMENT_SECONDS);
+        int cooldownSeconds = parseInt(arguments.get("cooldownSeconds"), DEFAULT_COOLDOWN_SECONDS);
+
+        Map<String, ScenarioDefinition> catalog = QuickTestScenarioCatalog.defaultScenarios();
+        List<ScenarioDefinition> selected = selectScenarios(arguments.get("scenarios"), catalog);
+
+        QuickTestPlan plan = new QuickTestPlan(warmupSeconds, measurementSeconds, cooldownSeconds, selected);
+        Path outputPath = Path.of(outputDir);
+        ResultsWriter.writePlan(outputPath, plan);
+
+        EnvironmentMetadata metadata = EnvironmentMetadata.fromSystem(System.getenv());
+
+        List<BenchmarkResult> results = new ArrayList<>();
+        for (ScenarioDefinition scenario : selected) {
+            results.add(runScenario(scenario, sampleDir));
+        }
+
+        ResultsWriter.writeResults(
+            outputPath,
+            modpack,
+            seed,
+            selected.stream().map(ScenarioDefinition::getId).toList(),
+            metadata,
+            plan,
+            sampleDir == null ? "none" : sampleDir,
+            results
+        );
+
+        System.out.printf(Locale.ROOT, "Quick test plan + results written to %s%n", outputPath.toAbsolutePath());
+    }
+
+    private static BenchmarkResult runScenario(ScenarioDefinition scenario, String sampleDir) throws IOException {
+        if (sampleDir == null) {
+            return new BenchmarkResult(
+                scenario.getId(),
+                scenario.getTitle(),
+                Double.NaN,
+                Double.NaN,
+                null,
+                0,
+                0,
+                "No sample data provided; execute scenario and supply samples to compute P95/P99."
+            );
+        }
+
+        Path samplePath = resolveSamplePath(sampleDir, scenario.getId());
+        if (samplePath == null || !Files.exists(samplePath)) {
+            return new BenchmarkResult(
+                scenario.getId(),
+                scenario.getTitle(),
+                Double.NaN,
+                Double.NaN,
+                null,
+                0,
+                0,
+                "Sample file not found for scenario."
+            );
+        }
+
+        List<Double> samples = readSamples(samplePath);
+        FrametimeStats.StatsResult stats = FrametimeStats.compute(samples);
+        String notes = stats.p99Valid() ? "" : "P99 requires >= 2000 samples; insufficient sample count.";
+        Double p99 = stats.p99Valid() ? stats.p99Ms() : null;
+        return new BenchmarkResult(
+            scenario.getId(),
+            scenario.getTitle(),
+            stats.averageMs(),
+            stats.p95Ms(),
+            p99,
+            stats.spikeCount(),
+            stats.sampleCount(),
+            notes
+        );
+    }
+
+    private static Path resolveSamplePath(String sampleDir, String scenarioId) {
+        Path base = Path.of(sampleDir);
+        Path csv = base.resolve(scenarioId + ".csv");
+        if (Files.exists(csv)) {
+            return csv;
+        }
+        Path txt = base.resolve(scenarioId + ".txt");
+        if (Files.exists(txt)) {
+            return txt;
+        }
+        return null;
+    }
+
+    private static List<Double> readSamples(Path samplePath) throws IOException {
+        List<String> lines = Files.readAllLines(samplePath);
+        List<Double> values = new ArrayList<>();
+        for (String line : lines) {
+            if (line == null || line.isBlank()) {
+                continue;
+            }
+            List<String> tokens = Arrays.stream(line.split("[,;\\s]+"))
+                .filter(token -> !token.isBlank())
+                .collect(Collectors.toList());
+            for (String token : tokens) {
+                values.add(Double.parseDouble(token));
+            }
+        }
+        return values;
+    }
+
+    private static List<ScenarioDefinition> selectScenarios(String scenarioArg, Map<String, ScenarioDefinition> catalog) {
+        if (scenarioArg == null || scenarioArg.isBlank()) {
+            return new ArrayList<>(catalog.values());
+        }
+        List<String> ids = Arrays.stream(scenarioArg.split(","))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .collect(Collectors.toList());
+        return ids.stream()
+            .map(id -> Optional.ofNullable(catalog.get(id))
+                .orElseThrow(() -> new IllegalArgumentException("Unknown scenario: " + id)))
+            .collect(Collectors.toList());
+    }
+
+    private static Map<String, String> parseArgs(String[] args) {
+        Map<String, String> values = new LinkedHashMap<>();
+        List<String> tokens = new ArrayList<>(Arrays.asList(args));
+        for (int i = 0; i < tokens.size(); i++) {
+            String token = tokens.get(i);
+            if (!token.startsWith("--")) {
+                continue;
+            }
+            String key = token.substring(2);
+            String value = (i + 1) < tokens.size() ? tokens.get(i + 1) : null;
+            if (value != null && !value.startsWith("--")) {
+                values.put(key, value);
+                i++;
+            } else {
+                values.put(key, "");
+            }
+        }
+        normalizeArgs(values);
+        return values;
+    }
+
+    private static void normalizeArgs(Map<String, String> values) {
+        rename(values, "scenarios", "scenarios");
+        rename(values, "modpack", "modpack");
+        rename(values, "seed", "seed");
+        rename(values, "output", "output");
+        rename(values, "samples", "samples");
+        rename(values, "warmup", "warmupSeconds");
+        rename(values, "measurement", "measurementSeconds");
+        rename(values, "cooldown", "cooldownSeconds");
+    }
+
+    private static void rename(Map<String, String> values, String from, String to) {
+        if (!Objects.equals(from, to) && values.containsKey(from)) {
+            values.putIfAbsent(to, values.remove(from));
+        }
+    }
+
+    private static int parseInt(String value, int fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException ex) {
+            return fallback;
+        }
+    }
+}

--- a/src/test/java/dev/nozh/core/testing/QuickTestPlan.java
+++ b/src/test/java/dev/nozh/core/testing/QuickTestPlan.java
@@ -1,0 +1,20 @@
+package dev.nozh.core.testing;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public record QuickTestPlan(
+    int warmupSeconds,
+    int measurementSeconds,
+    int cooldownSeconds,
+    List<ScenarioDefinition> scenarios
+) {
+    public Map<String, Integer> timingMap() {
+        Map<String, Integer> timing = new LinkedHashMap<>();
+        timing.put("warmup_seconds", warmupSeconds);
+        timing.put("measurement_seconds", measurementSeconds);
+        timing.put("cooldown_seconds", cooldownSeconds);
+        return timing;
+    }
+}

--- a/src/test/java/dev/nozh/core/testing/QuickTestScenarioCatalog.java
+++ b/src/test/java/dev/nozh/core/testing/QuickTestScenarioCatalog.java
@@ -1,0 +1,64 @@
+package dev.nozh.core.testing;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class QuickTestScenarioCatalog {
+    private QuickTestScenarioCatalog() {
+    }
+
+    public static Map<String, ScenarioDefinition> defaultScenarios() {
+        Map<String, ScenarioDefinition> scenarios = new LinkedHashMap<>();
+
+        scenarios.put("mobs", new ScenarioDefinition(
+            "mobs",
+            "Mobs (combate / entidades)",
+            "Zona con alta densidad de entidades para evaluar spikes en combate e inventario.",
+            180,
+            List.of(
+                ScenarioStep.teleport("/tp <x> <y> <z>", "Teleport a spawner/granja con alta densidad de entidades."),
+                ScenarioStep.action("Combate constante con patrón fijo (arma + ruta).", 180),
+                ScenarioStep.action("Abrir inventario durante combate para detectar spikes.", 30)
+            )
+        ));
+
+        scenarios.put("mining", new ScenarioDefinition(
+            "mining",
+            "Minería (subterráneo / partículas)",
+            "Cueva con agua, lava y partículas activas para validar chunk gen y estabilidad.",
+            180,
+            List.of(
+                ScenarioStep.teleport("/tp <x> <y> <z>", "Teleport a cueva con agua/lava/partículas."),
+                ScenarioStep.action("Minar y moverse por la cueva manteniendo partículas activas.", 180),
+                ScenarioStep.action("Forzar generación de nuevos chunks al avanzar.", 60)
+            )
+        ));
+
+        scenarios.put("nether", new ScenarioDefinition(
+            "nether",
+            "Nether (carga y efectos)",
+            "Recorrido por biomas con efectos de partículas y teleports en Nether.",
+            180,
+            List.of(
+                ScenarioStep.teleport("/tp <x> <y> <z>", "Entrar al Nether y posicionarse en el bioma objetivo."),
+                ScenarioStep.action("Recorrer biomas con efectos activos para observar spikes.", 180),
+                ScenarioStep.action("Realizar teleport corto entre biomas para validar cargas.", 30)
+            )
+        ));
+
+        scenarios.put("rain", new ScenarioDefinition(
+            "rain",
+            "Lluvia (clima / shaders)",
+            "Validar impacto de lluvia o shaders sobre el frametime sostenido.",
+            180,
+            List.of(
+                ScenarioStep.action("Forzar lluvia si el modpack lo permite o esperar clima natural.", 60),
+                ScenarioStep.action("Mantener posición fija con lluvia activa y observar p95.", 180),
+                ScenarioStep.note("Revisar si se requiere rollback o sugerencias de config.")
+            )
+        ));
+
+        return scenarios;
+    }
+}

--- a/src/test/java/dev/nozh/core/testing/ResultsWriter.java
+++ b/src/test/java/dev/nozh/core/testing/ResultsWriter.java
@@ -1,0 +1,78 @@
+package dev.nozh.core.testing;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class ResultsWriter {
+    private ResultsWriter() {
+    }
+
+    public static void writePlan(Path outputDir, QuickTestPlan plan) throws IOException {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Path output = outputDir.resolve("quick-test-plan.json");
+        Files.createDirectories(outputDir);
+        Files.writeString(output, gson.toJson(plan));
+    }
+
+    public static void writeResults(
+        Path outputDir,
+        String modpack,
+        String seed,
+        List<String> scenarios,
+        EnvironmentMetadata metadata,
+        QuickTestPlan plan,
+        String sampleSource,
+        List<BenchmarkResult> results
+    ) throws IOException {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Map<String, Object> payload = new HashMap<>();
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("modpack", modpack);
+        meta.put("seed", seed);
+        meta.put("scenarios", scenarios);
+        meta.put("environment", metadata.getValues());
+        meta.put("timing", plan.timingMap());
+        meta.put("sample_source", sampleSource);
+        meta.put("generated_at", Instant.now().toString());
+        payload.put("metadata", meta);
+        payload.put("results", results);
+        Files.createDirectories(outputDir);
+        Files.writeString(outputDir.resolve("quick-test-results.json"), gson.toJson(payload));
+
+        writeCsv(outputDir.resolve("quick-test-results.csv"), results);
+    }
+
+    private static void writeCsv(Path output, List<BenchmarkResult> results) throws IOException {
+        try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(output))) {
+            writer.println("scenario,avg_ms,p95_ms,p99_ms,spike_count,samples,notes");
+            for (BenchmarkResult result : results) {
+                writer.printf(
+                    "%s,%.3f,%.3f,%s,%d,%d,%s%n",
+                    result.getScenarioName(),
+                    result.getAverageMs(),
+                    result.getP95Ms(),
+                    result.getP99Ms() == null ? "" : String.format("%.3f", result.getP99Ms()),
+                    result.getSpikeCount(),
+                    result.getSampleCount(),
+                    escapeCsv(result.getNotes())
+                );
+            }
+        }
+    }
+
+    private static String escapeCsv(String value) {
+        if (value == null || value.isEmpty()) {
+            return "";
+        }
+        String escaped = value.replace("\"", "\"\"");
+        return '"' + escaped + '"';
+    }
+}

--- a/src/test/java/dev/nozh/core/testing/ScenarioDefinition.java
+++ b/src/test/java/dev/nozh/core/testing/ScenarioDefinition.java
@@ -1,0 +1,40 @@
+package dev.nozh.core.testing;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class ScenarioDefinition {
+    private final String id;
+    private final String title;
+    private final String description;
+    private final int defaultDurationSeconds;
+    private final List<ScenarioStep> steps;
+
+    public ScenarioDefinition(String id, String title, String description, int defaultDurationSeconds, List<ScenarioStep> steps) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.defaultDurationSeconds = defaultDurationSeconds;
+        this.steps = List.copyOf(steps);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getDefaultDurationSeconds() {
+        return defaultDurationSeconds;
+    }
+
+    public List<ScenarioStep> getSteps() {
+        return Collections.unmodifiableList(steps);
+    }
+}

--- a/src/test/java/dev/nozh/core/testing/ScenarioStep.java
+++ b/src/test/java/dev/nozh/core/testing/ScenarioStep.java
@@ -1,0 +1,54 @@
+package dev.nozh.core.testing;
+
+public final class ScenarioStep {
+    public enum StepType {
+        TELEPORT,
+        ACTION,
+        WAIT,
+        NOTE
+    }
+
+    private final StepType type;
+    private final String description;
+    private final String command;
+    private final Integer durationSeconds;
+
+    private ScenarioStep(StepType type, String description, String command, Integer durationSeconds) {
+        this.type = type;
+        this.description = description;
+        this.command = command;
+        this.durationSeconds = durationSeconds;
+    }
+
+    public static ScenarioStep teleport(String command, String description) {
+        return new ScenarioStep(StepType.TELEPORT, description, command, null);
+    }
+
+    public static ScenarioStep action(String description, int durationSeconds) {
+        return new ScenarioStep(StepType.ACTION, description, null, durationSeconds);
+    }
+
+    public static ScenarioStep waitFor(String description, int durationSeconds) {
+        return new ScenarioStep(StepType.WAIT, description, null, durationSeconds);
+    }
+
+    public static ScenarioStep note(String description) {
+        return new ScenarioStep(StepType.NOTE, description, null, null);
+    }
+
+    public StepType getType() {
+        return type;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public Integer getDurationSeconds() {
+        return durationSeconds;
+    }
+}


### PR DESCRIPTION
### Motivation
- Implementar un ejecutor reproducible que convierta el checklist de `docs/modpack-quick-test.md` en pasos programáticos para pruebas rápidas de modpacks. 
- Generar salidas estructuradas que sigan el formato de `docs/benchmarking.md` para P95/P99 y metadatos de entorno. 
- Permitir invocación desde CI o local mediante una tarea Gradle parametrizable con modpack, seed y lista de escenarios. 
- Documentar cómo preparar y ejecutar runners para modpacks grandes (Better Minecraft, ATM9) y cómo usar la tarea. 

### Description
- Añadidos nuevos artefactos bajo `src/test/java/dev/nozh/core/testing`: `ModpackQuickTestRunner`, `QuickTestScenarioCatalog`, `QuickTestPlan`, `ScenarioDefinition`, `ScenarioStep`, `FrametimeStats`, `BenchmarkResult`, `EnvironmentMetadata` y `ResultsWriter` para modelar escenarios, leer muestras y escribir JSON/CSV. 
- Se añadió la tarea Gradle `quickTest` en `build.gradle` que ejecuta `dev.nozh.core.testing.ModpackQuickTestRunner` y mapea propiedades de proyecto a flags (`-Pmodpack`, `-Pseed`, `-Pscenarios`, `-PoutputDir`, `-PsamplesDir`, `-PwarmupSeconds`, `-PmeasurementSeconds`, `-PcooldownSeconds`). 
- Implementada lectura de muestras desde archivos `.csv`/`.txt` con parsing flexible, cálculo de estadísticas (promedio, P95, P99 con verificación de >=2000 muestras) y conteo de spikes, y escritura de `quick-test-plan.json`, `quick-test-results.json` y `quick-test-results.csv`. 
- Añadido `docs/automated-quick-test.md` con ejemplos de invocación (`./gradlew quickTest ...`), formato de muestras, variables de entorno para metadatos y recomendaciones para modpacks grandes. 

### Testing
- No se ejecutaron pruebas automatizadas como parte de este cambio. 
- La nueva tarea `quickTest` fue registrada en Gradle pero no fue ejecutada en este rollout. 
- Los tests unitarios existentes del repositorio no se ejecutaron durante esta modificación. 
- Ninguna comprobación automatizada adicional (CI/build) se corrió para validar la salida JSON/CSV en este PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da200b4a0832db58c31d41d3c9635)