### PR TITLE
Add entity/chunk/shader chaos scenarios and report metadata

### DIFF
--- a/src/main/java/dev/nozh/core/testing/ChaosReportMetadata.java
+++ b/src/main/java/dev/nozh/core/testing/ChaosReportMetadata.java
@@ -1,0 +1,10 @@
+package dev.nozh.core.testing;
+
+/**
+ * Chaos test report metadata for correlating benchmark results.
+ */
+public record ChaosReportMetadata(
+        int renderDistance,
+        int simulationDistance,
+        String shaderPack) {
+}

--- a/src/main/java/dev/nozh/core/testing/ChaosScenario.java
+++ b/src/main/java/dev/nozh/core/testing/ChaosScenario.java
@@ -6,13 +6,52 @@ package dev.nozh.core.testing;
  * Defines stress test scenarios for system resilience.
  */
 public enum ChaosScenario {
+    /**
+     * Stress provider init with intermittent failures.
+     */
     PROVIDER_INIT_FAILURE,
+    /**
+     * Attempt repeated invariant violations to ensure rejection.
+     */
     INVARIANT_VIOLATION_ATTEMPT,
+    /**
+     * Flood command queue to validate overflow handling.
+     */
     QUEUE_OVERFLOW,
+    /**
+     * Starve telemetry buffer under massive sample load.
+     */
     TELEMETRY_STARVATION,
+    /**
+     * Force governor state changes to test flapping control.
+     */
     GOVERNOR_FLAPPING,
+    /**
+     * Violate preset bounds to confirm enforcement.
+     */
     PRESET_VIOLATION,
+    /**
+     * Dispatch while safe mode active to validate rejection.
+     */
     SAFEMODE_DISPATCH,
+    /**
+     * Corrupt HUD snapshot to ensure safe fallback.
+     */
     HUD_SNAPSHOT_CORRUPTION,
-    CRASH_LOOP_RECOVERY
+    /**
+     * Trigger crash loop recovery escalation.
+     */
+    CRASH_LOOP_RECOVERY,
+    /**
+     * Megabase entity swarm scenario (300+ entities).
+     */
+    ENTITY_SWARM,
+    /**
+     * Chunk loading spam under mining stress.
+     */
+    CHUNK_SPAM,
+    /**
+     * Shader load toggling under rain-like pressure.
+     */
+    SHADER_LOAD
 }

--- a/src/main/java/dev/nozh/core/testing/ChaosTestReport.java
+++ b/src/main/java/dev/nozh/core/testing/ChaosTestReport.java
@@ -12,7 +12,8 @@ public record ChaosTestReport(
         int totalScenarios,
         int passed,
         int failed,
-        long totalDurationMs) {
+        long totalDurationMs,
+        ChaosReportMetadata metadata) {
     /**
      * Check if all scenarios passed.
      */

--- a/src/main/java/dev/nozh/core/testing/ChaosTestRunner.java
+++ b/src/main/java/dev/nozh/core/testing/ChaosTestRunner.java
@@ -77,7 +77,7 @@ public final class ChaosTestRunner {
         int passed = (int) results.stream().filter(ChaosScenarioResult::passed).count();
         int failed = results.size() - passed;
 
-        return new ChaosTestReport(results, results.size(), passed, failed, totalDuration);
+        return new ChaosTestReport(results, results.size(), passed, failed, totalDuration, buildReportMetadata());
     }
 
     /**
@@ -108,6 +108,12 @@ public final class ChaosTestRunner {
                     return testHudSnapshotCorruption(start);
                 case CRASH_LOOP_RECOVERY:
                     return testCrashLoopRecovery(start);
+                case ENTITY_SWARM:
+                    return testEntitySwarm(start);
+                case CHUNK_SPAM:
+                    return testChunkSpam(start);
+                case SHADER_LOAD:
+                    return testShaderLoad(start);
                 default:
                     return ChaosScenarioResult.fail(scenario, "Unknown scenario", 0);
             }
@@ -437,6 +443,103 @@ public final class ChaosTestRunner {
         return ChaosScenarioResult.pass(ChaosScenario.CRASH_LOOP_RECOVERY, duration);
     }
 
+    private static ChaosScenarioResult testEntitySwarm(long start) {
+        int entityCount = 350;
+        int ticks = 240;
+        List<SimulatedEntity> entities = new ArrayList<>(entityCount);
+        for (int i = 0; i < entityCount; i++) {
+            entities.add(new SimulatedEntity(i, i % 23, i % 17));
+        }
+
+        int updates = 0;
+        double accumulatedMotion = 0.0;
+        for (int tick = 0; tick < ticks; tick++) {
+            for (SimulatedEntity entity : entities) {
+                entity.step(tick);
+                accumulatedMotion += entity.energy();
+                updates++;
+            }
+        }
+
+        if (updates != entityCount * ticks) {
+            long duration = System.currentTimeMillis() - start;
+            return ChaosScenarioResult.fail(ChaosScenario.ENTITY_SWARM,
+                    "Entity updates mismatch: " + updates, duration);
+        }
+
+        if (!Double.isFinite(accumulatedMotion) || accumulatedMotion <= 0.0) {
+            long duration = System.currentTimeMillis() - start;
+            return ChaosScenarioResult.fail(ChaosScenario.ENTITY_SWARM,
+                    "Entity simulation produced invalid motion", duration);
+        }
+
+        long duration = System.currentTimeMillis() - start;
+        return ChaosScenarioResult.pass(ChaosScenario.ENTITY_SWARM, duration);
+    }
+
+    private static ChaosScenarioResult testChunkSpam(long start) {
+        int requests = 5000;
+        int processed = 0;
+        int maxQueue = 0;
+        java.util.ArrayDeque<ChunkRequest> queue = new java.util.ArrayDeque<>();
+
+        for (int i = 0; i < requests; i++) {
+            queue.add(new ChunkRequest(i, i % 2 == 0));
+            maxQueue = Math.max(maxQueue, queue.size());
+            if (i % 3 == 0) {
+                processed += drainQueue(queue, 5);
+            }
+        }
+
+        processed += drainQueue(queue, queue.size());
+
+        if (processed != requests) {
+            long duration = System.currentTimeMillis() - start;
+            return ChaosScenarioResult.fail(ChaosScenario.CHUNK_SPAM,
+                    "Chunk requests processed mismatch: " + processed, duration);
+        }
+
+        if (maxQueue < 500) {
+            long duration = System.currentTimeMillis() - start;
+            return ChaosScenarioResult.fail(ChaosScenario.CHUNK_SPAM,
+                    "Chunk spam did not reach stress threshold", duration);
+        }
+
+        long duration = System.currentTimeMillis() - start;
+        return ChaosScenarioResult.pass(ChaosScenario.CHUNK_SPAM, duration);
+    }
+
+    private static ChaosScenarioResult testShaderLoad(long start) {
+        String[] shaderPacks = {"OFF", "RAIN_STORM", "CINEMATIC", "PERFORMANCE"};
+        String current = shaderPacks[0];
+        int toggles = 0;
+        double shaderCost = 0.0;
+
+        for (int i = 0; i < 240; i++) {
+            String next = shaderPacks[i % shaderPacks.length];
+            if (!next.equals(current)) {
+                toggles++;
+                current = next;
+            }
+            shaderCost += simulateShaderFrameCost(current, i);
+        }
+
+        if (toggles < 100) {
+            long duration = System.currentTimeMillis() - start;
+            return ChaosScenarioResult.fail(ChaosScenario.SHADER_LOAD,
+                    "Shader toggling did not occur frequently enough", duration);
+        }
+
+        if (!Double.isFinite(shaderCost) || shaderCost <= 0.0) {
+            long duration = System.currentTimeMillis() - start;
+            return ChaosScenarioResult.fail(ChaosScenario.SHADER_LOAD,
+                    "Shader load simulation produced invalid cost", duration);
+        }
+
+        long duration = System.currentTimeMillis() - start;
+        return ChaosScenarioResult.pass(ChaosScenario.SHADER_LOAD, duration);
+    }
+
     private ChaosTestRunner() {
         // Static utility
     }
@@ -498,6 +601,82 @@ public final class ChaosTestRunner {
                 state.scenarioHistory(),
                 state.baselineSettings(),
                 state.currentSettings());
+    }
+
+    private static ChaosReportMetadata buildReportMetadata() {
+        int renderDistance = Integer.getInteger("nozh.chaos.renderDistance", 16);
+        int simulationDistance = Integer.getInteger("nozh.chaos.simulationDistance", 12);
+        String shaderPack = System.getProperty("nozh.chaos.shaderPack", "OFF");
+        return new ChaosReportMetadata(renderDistance, simulationDistance, shaderPack);
+    }
+
+    private static int drainQueue(java.util.ArrayDeque<ChunkRequest> queue, int max) {
+        int drained = 0;
+        int entropy = 0;
+        while (!queue.isEmpty() && drained < max) {
+            ChunkRequest request = queue.removeFirst();
+            entropy ^= request.id();
+            if (request.isLoad()) {
+                drained++;
+            } else {
+                drained++;
+            }
+        }
+        if (entropy == Integer.MIN_VALUE) {
+            return drained;
+        }
+        return drained;
+    }
+
+    private static double simulateShaderFrameCost(String shaderPack, int frame) {
+        double base = 2.5;
+        double packMultiplier = switch (shaderPack) {
+            case "RAIN_STORM" -> 3.5;
+            case "CINEMATIC" -> 3.0;
+            case "PERFORMANCE" -> 1.5;
+            default -> 1.0;
+        };
+        return base * packMultiplier + (frame % 7) * 0.1;
+    }
+
+    private static final class SimulatedEntity {
+        private double x;
+        private double y;
+        private double z;
+
+        private SimulatedEntity(double x, double y, double z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        private void step(int tick) {
+            x += Math.sin(tick * 0.05 + x) * 0.1;
+            y += Math.cos(tick * 0.03 + y) * 0.1;
+            z += Math.sin(tick * 0.04 + z) * 0.1;
+        }
+
+        private double energy() {
+            return x * x + y * y + z * z;
+        }
+    }
+
+    private static final class ChunkRequest {
+        private final int id;
+        private final boolean load;
+
+        private ChunkRequest(int id, boolean load) {
+            this.id = id;
+            this.load = load;
+        }
+
+        private boolean isLoad() {
+            return load;
+        }
+
+        private int id() {
+            return id;
+        }
     }
 
     private static final class IntermittentChaosProvider implements CapabilityProvider {


### PR DESCRIPTION
### Motivation
- Add stress scenarios aligned with `docs/benchmarking.md` and `docs/modpack-quick-test.md` to cover heavy-entity, chunk-load, and shader/rain pressure cases.
- Extend the existing chaos test surface so resilience checks run as pure-core simulations without MC dependencies.
- Capture renderer/simulation configuration in reports to allow correlation between environment and outcomes.

### Description
- Extend `ChaosScenario` with `ENTITY_SWARM`, `CHUNK_SPAM`, and `SHADER_LOAD` and add Javadoc for each new entry.
- Implement `testEntitySwarm`, `testChunkSpam`, and `testShaderLoad` in `ChaosTestRunner` with deterministic simulated entities, chunk request queuing, and shader-cost toggling respectively, and wire them into the scenario dispatcher via `runScenario`.
- Add `ChaosReportMetadata` record and include it in `ChaosTestReport`, with `buildReportMetadata()` reading `nozh.chaos.renderDistance`, `nozh.chaos.simulationDistance`, and `nozh.chaos.shaderPack` system properties.
- Add small helpers (`SimulatedEntity`, `ChunkRequest`, `simulateShaderFrameCost`, `drainQueue`) to support the simulated stress workloads.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da4c3ea9c832da230b5a0c8ab2249)