### PR TITLE
Add benchmark scenario artifact recording

### DIFF
--- a/src/main/java/dev/nozh/client/NozhModClient.java
+++ b/src/main/java/dev/nozh/client/NozhModClient.java
@@ -14,7 +14,10 @@ import dev.nozh.core.safety.CrashLoopGuard;
 import dev.nozh.core.state.RuntimeState;
 import dev.nozh.core.state.StateStore;
 import dev.nozh.core.benchmark.InitialBenchmarkRunner;
+import dev.nozh.core.benchmark.BenchmarkEnvironment;
+import dev.nozh.core.benchmark.BenchmarkScenarioRecorder;
 import dev.nozh.core.telemetry.TelemetryManager;
+import dev.nozh.core.context.Scenario;
 import dev.nozh.fabric.FabricNozhLogger;
 import dev.nozh.fabric.capability.CompatAwareMinecraftOptionsAdapter;
 import dev.nozh.fabric.capability.MinecraftOptionsAdapter;
@@ -24,6 +27,7 @@ import dev.nozh.fabric.capability.StandardCapabilityExecutor;
 import dev.nozh.fabric.compat.CompatRegistry;
 import dev.nozh.fabric.input.ManualConfirmationHandler;
 import dev.nozh.client.hud.NozhHudRenderer;
+import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -57,6 +61,7 @@ public class NozhModClient implements ClientModInitializer {
     private static ProviderRegistry providerRegistry;
     private static dev.nozh.fabric.context.FabricScenarioDetector scenarioDetector;
     private static InitialBenchmarkRunner initialBenchmarkRunner;
+    private static BenchmarkScenarioRecorder benchmarkScenarioRecorder;
     private static KeyBinding toggleHudKey;
     private static KeyBinding applySuggestionKey;
     private static KeyBinding exportReportKey;
@@ -134,8 +139,19 @@ public class NozhModClient implements ClientModInitializer {
         perfManager = new dev.nozh.core.profiler.PerfManager();
         tickTimeSampler = new dev.nozh.core.monitoring.TickTimeSampler();
         perfManager.setTickSnapshotSupplier(() -> tickTimeSampler.getSnapshot());
+        if (ConfigManager.getConfig().benchmarkModeEnabled) {
+            benchmarkScenarioRecorder = new BenchmarkScenarioRecorder(
+                    perfManager,
+                    () -> perfManager != null ? perfManager.getSnapshot() : dev.nozh.api.PerfSnapshot.empty(),
+                    NozhConstants.CONFIG_DIR.resolve("benchmark_artifacts"));
+        }
         initialBenchmarkRunner = new InitialBenchmarkRunner(stateStore,
-                () -> perfManager != null ? perfManager.getSnapshot() : dev.nozh.api.PerfSnapshot.empty());
+                () -> perfManager != null ? perfManager.getSnapshot() : dev.nozh.api.PerfSnapshot.empty(),
+                snapshot -> {
+                    if (benchmarkScenarioRecorder != null) {
+                        benchmarkScenarioRecorder.recordInitialBenchmarkSnapshot(snapshot);
+                    }
+                });
 
         // 8. Create ActionProcessor bridge
         StandardActionProcessor actionProcessor = new StandardActionProcessor(
@@ -286,6 +302,10 @@ public class NozhModClient implements ClientModInitializer {
             if (initialBenchmarkRunner != null) {
                 initialBenchmarkRunner.tick();
             }
+            if (benchmarkScenarioRecorder != null) {
+                Scenario scenario = stateStore.snapshotSafe().currentScenario();
+                benchmarkScenarioRecorder.tick(scenario);
+            }
 
             handleTutorial(clientInstance);
 
@@ -300,6 +320,9 @@ public class NozhModClient implements ClientModInitializer {
             }
             if (initialBenchmarkRunner != null) {
                 initialBenchmarkRunner.onSessionEnd();
+            }
+            if (benchmarkScenarioRecorder != null) {
+                benchmarkScenarioRecorder.onSessionEnd();
             }
         });
 
@@ -317,6 +340,9 @@ public class NozhModClient implements ClientModInitializer {
             }
             if (initialBenchmarkRunner != null) {
                 initialBenchmarkRunner.onSessionStart();
+            }
+            if (benchmarkScenarioRecorder != null) {
+                benchmarkScenarioRecorder.onSessionStart(buildBenchmarkEnvironment(clientInstance));
             }
         });
 
@@ -380,6 +406,19 @@ public class NozhModClient implements ClientModInitializer {
 
     public static dev.nozh.fabric.context.FabricScenarioDetector getScenarioDetector() {
         return scenarioDetector;
+    }
+
+    private BenchmarkEnvironment buildBenchmarkEnvironment(MinecraftClient clientInstance) {
+        String hardwareProfile = ConfigManager.getConfig().hardwareProfile;
+        String resolution = "unknown";
+        if (clientInstance != null && clientInstance.getWindow() != null) {
+            resolution = clientInstance.getWindow().getFramebufferWidth()
+                    + "x" + clientInstance.getWindow().getFramebufferHeight();
+        }
+        int modCount = FabricLoader.getInstance().getAllMods().size();
+        String modsSummary = "mods=" + modCount;
+        String workloadProfile = ConfigManager.getConfig().optimizationProfile;
+        return new BenchmarkEnvironment(hardwareProfile, resolution, modsSummary, workloadProfile);
     }
 
     public static void requestSuggestedAction() {

--- a/src/main/java/dev/nozh/core/benchmark/BenchmarkArtifactMetadata.java
+++ b/src/main/java/dev/nozh/core/benchmark/BenchmarkArtifactMetadata.java
@@ -1,0 +1,46 @@
+package dev.nozh.core.benchmark;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Metadata for a benchmark artifact bundle.
+ */
+public record BenchmarkArtifactMetadata(
+        BenchmarkEnvironment environment,
+        String scenario,
+        long scenarioStartMillis,
+        long scenarioEndMillis,
+        Path telemetryCsv,
+        Path telemetryJson,
+        Path snapshotsJson,
+        Path initialBenchmarkSnapshotJson) {
+
+    public String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"environment\": ").append(environment != null ? environment.toJson() : "null").append(",\n");
+        sb.append("  \"scenario\": \"").append(escapeJson(scenario)).append("\",\n");
+        sb.append("  \"scenarioStartMillis\": ").append(scenarioStartMillis).append(",\n");
+        sb.append("  \"scenarioEndMillis\": ").append(scenarioEndMillis).append(",\n");
+        sb.append("  \"telemetryCsv\": ").append(formatPath(telemetryCsv)).append(",\n");
+        sb.append("  \"telemetryJson\": ").append(formatPath(telemetryJson)).append(",\n");
+        sb.append("  \"snapshotsJson\": ").append(formatPath(snapshotsJson)).append(",\n");
+        sb.append("  \"initialBenchmarkSnapshotJson\": ").append(formatPath(initialBenchmarkSnapshotJson)).append("\n");
+        sb.append("}\n");
+        return sb.toString();
+    }
+
+    private String formatPath(Path path) {
+        if (path == null) {
+            return "null";
+        }
+        return "\"" + escapeJson(path.toString()) + "\"";
+    }
+
+    private static String escapeJson(String value) {
+        return Objects.toString(value, "")
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/dev/nozh/core/benchmark/BenchmarkEnvironment.java
+++ b/src/main/java/dev/nozh/core/benchmark/BenchmarkEnvironment.java
@@ -1,0 +1,44 @@
+package dev.nozh.core.benchmark;
+
+import java.util.Objects;
+
+/**
+ * Benchmark environment descriptor (hardware, resolution, mods, workload).
+ */
+public record BenchmarkEnvironment(
+        String hardwareProfile,
+        String resolution,
+        String mods,
+        String workloadProfile) {
+
+    public BenchmarkEnvironment {
+        hardwareProfile = normalize(hardwareProfile, "unknown");
+        resolution = normalize(resolution, "unknown");
+        mods = normalize(mods, "unknown");
+        workloadProfile = normalize(workloadProfile, "default");
+    }
+
+    private static String normalize(String value, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return value.trim();
+    }
+
+    public String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"hardwareProfile\": \"").append(escapeJson(hardwareProfile)).append("\",\n");
+        sb.append("  \"resolution\": \"").append(escapeJson(resolution)).append("\",\n");
+        sb.append("  \"mods\": \"").append(escapeJson(mods)).append("\",\n");
+        sb.append("  \"workloadProfile\": \"").append(escapeJson(workloadProfile)).append("\"\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private static String escapeJson(String value) {
+        return Objects.toString(value, "")
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/dev/nozh/core/benchmark/BenchmarkMatrix.java
+++ b/src/main/java/dev/nozh/core/benchmark/BenchmarkMatrix.java
@@ -1,0 +1,50 @@
+package dev.nozh.core.benchmark;
+
+import java.util.List;
+
+/**
+ * Benchmark matrix for environment coverage and scenario usage.
+ */
+public record BenchmarkMatrix(
+        List<BenchmarkEnvironment> environments,
+        List<BenchmarkScenario> scenarios) {
+
+    public static BenchmarkMatrix defaultMatrix() {
+        List<BenchmarkEnvironment> environments = List.of(
+                new BenchmarkEnvironment("low-tier CPU + iGPU", "1280x720", "vanilla+lite", "cpu-bound"),
+                new BenchmarkEnvironment("mid-tier CPU + mid GPU", "1920x1080", "modpack", "balanced"),
+                new BenchmarkEnvironment("high-tier CPU + high GPU", "2560x1440", "shader-heavy", "gpu-bound"));
+        List<BenchmarkScenario> scenarios = List.of(
+                new BenchmarkScenario("MENU", "Launcher/menu navigation", 45),
+                new BenchmarkScenario("EXPLORING", "Overworld traversal with chunk generation", 120),
+                new BenchmarkScenario("COMBAT", "High-entity combat encounter", 90),
+                new BenchmarkScenario("BUILDING", "Structure placement with redstone updates", 90),
+                new BenchmarkScenario("LOADING", "Dimension or world load transition", 60));
+        return new BenchmarkMatrix(environments, scenarios);
+    }
+
+    public String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"environments\": [\n");
+        for (int i = 0; i < environments.size(); i++) {
+            sb.append("    ").append(environments.get(i).toJson());
+            if (i < environments.size() - 1) {
+                sb.append(',');
+            }
+            sb.append('\n');
+        }
+        sb.append("  ],\n");
+        sb.append("  \"scenarios\": [\n");
+        for (int i = 0; i < scenarios.size(); i++) {
+            sb.append("    ").append(scenarios.get(i).toJson());
+            if (i < scenarios.size() - 1) {
+                sb.append(',');
+            }
+            sb.append('\n');
+        }
+        sb.append("  ]\n");
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/src/main/java/dev/nozh/core/benchmark/BenchmarkScenario.java
+++ b/src/main/java/dev/nozh/core/benchmark/BenchmarkScenario.java
@@ -1,0 +1,43 @@
+package dev.nozh.core.benchmark;
+
+import java.util.Objects;
+
+/**
+ * Benchmark scenario definition for workload coverage.
+ */
+public record BenchmarkScenario(
+        String name,
+        String description,
+        int targetDurationSeconds) {
+
+    public BenchmarkScenario {
+        name = normalize(name, "UNKNOWN");
+        description = normalize(description, "");
+        if (targetDurationSeconds <= 0) {
+            targetDurationSeconds = 60;
+        }
+    }
+
+    private static String normalize(String value, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return value.trim();
+    }
+
+    public String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"name\":\"").append(escapeJson(name)).append("\",");
+        sb.append("\"description\":\"").append(escapeJson(description)).append("\",");
+        sb.append("\"targetDurationSeconds\":").append(targetDurationSeconds);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private static String escapeJson(String value) {
+        return Objects.toString(value, "")
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/dev/nozh/core/benchmark/BenchmarkScenarioRecorder.java
+++ b/src/main/java/dev/nozh/core/benchmark/BenchmarkScenarioRecorder.java
@@ -1,0 +1,184 @@
+package dev.nozh.core.benchmark;
+
+import dev.nozh.NozhConstants;
+import dev.nozh.api.PerfSnapshot;
+import dev.nozh.core.context.Scenario;
+import dev.nozh.core.profiler.PerfManager;
+import dev.nozh.core.telemetry.TelemetryExportFormat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Records scenario-based benchmark artifacts and telemetry exports.
+ */
+public final class BenchmarkScenarioRecorder {
+
+    private static final long SNAPSHOT_INTERVAL_MS = 1_000L;
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
+            .withZone(ZoneOffset.UTC);
+
+    private final PerfManager perfManager;
+    private final Supplier<PerfSnapshot> snapshotSupplier;
+    private final Path rootDir;
+    private final BenchmarkSnapshotSeries snapshotSeries = new BenchmarkSnapshotSeries();
+
+    private BenchmarkEnvironment environment;
+    private Scenario activeScenario;
+    private long scenarioStartMillis;
+    private long lastSnapshotMillis;
+    private boolean sessionActive;
+    private Path sessionDir;
+    private Path initialBenchmarkSnapshotJson;
+
+    public BenchmarkScenarioRecorder(PerfManager perfManager, Supplier<PerfSnapshot> snapshotSupplier, Path rootDir) {
+        this.perfManager = perfManager;
+        this.snapshotSupplier = snapshotSupplier != null ? snapshotSupplier : PerfSnapshot::empty;
+        this.rootDir = rootDir;
+    }
+
+    public void onSessionStart(BenchmarkEnvironment environment) {
+        this.environment = environment;
+        this.sessionActive = true;
+        this.activeScenario = null;
+        this.scenarioStartMillis = 0L;
+        this.lastSnapshotMillis = 0L;
+        this.snapshotSeries.clear();
+        this.initialBenchmarkSnapshotJson = null;
+        this.sessionDir = resolveSessionDir();
+        writeMatrixSnapshot();
+    }
+
+    public void onSessionEnd() {
+        if (!sessionActive) {
+            return;
+        }
+        closeScenario(System.currentTimeMillis());
+        sessionActive = false;
+    }
+
+    public void tick(Scenario scenario) {
+        if (!sessionActive) {
+            return;
+        }
+        Scenario resolvedScenario = scenario != null ? scenario : Scenario.STANDARD;
+        long now = System.currentTimeMillis();
+        if (activeScenario == null || activeScenario != resolvedScenario) {
+            closeScenario(now);
+            startScenario(resolvedScenario, now);
+        }
+        if (now - lastSnapshotMillis >= SNAPSHOT_INTERVAL_MS) {
+            captureSnapshot();
+            lastSnapshotMillis = now;
+        }
+    }
+
+    public void recordInitialBenchmarkSnapshot(PerfSnapshot snapshot) {
+        if (!sessionActive || snapshot == null || sessionDir == null) {
+            return;
+        }
+        try {
+            Path outputFile = sessionDir.resolve("initial_benchmark_snapshot.json");
+            BenchmarkSnapshotSeries series = new BenchmarkSnapshotSeries();
+            series.addSnapshot(snapshot);
+            series.writeJson(outputFile);
+            initialBenchmarkSnapshotJson = outputFile;
+        } catch (Exception e) {
+            NozhConstants.LOGGER.warn("Failed to write initial benchmark snapshot: {}", e.getMessage());
+        }
+    }
+
+    private void startScenario(Scenario scenario, long now) {
+        activeScenario = scenario;
+        scenarioStartMillis = now;
+        snapshotSeries.clear();
+    }
+
+    private void closeScenario(long now) {
+        if (activeScenario == null || sessionDir == null) {
+            return;
+        }
+        try {
+            TelemetryExportFormat[] formats = {TelemetryExportFormat.CSV, TelemetryExportFormat.JSON};
+            Path csv = null;
+            Path json = null;
+            for (TelemetryExportFormat format : formats) {
+                Path export = perfManager != null ? perfManager.exportTelemetry(sessionDir, format) : null;
+                if (format == TelemetryExportFormat.CSV) {
+                    csv = export;
+                } else {
+                    json = export;
+                }
+            }
+            Path snapshotsJson = null;
+            if (!snapshotSeries.isEmpty()) {
+                String timestamp = TIMESTAMP_FORMAT.format(Instant.ofEpochMilli(now));
+                snapshotsJson = sessionDir.resolve("snapshots_" + activeScenario.name().toLowerCase()
+                        + "_" + timestamp + ".json");
+                snapshotSeries.writeJson(snapshotsJson);
+            }
+            BenchmarkArtifactMetadata metadata = new BenchmarkArtifactMetadata(
+                    environment,
+                    activeScenario.name(),
+                    scenarioStartMillis,
+                    now,
+                    csv,
+                    json,
+                    snapshotsJson,
+                    initialBenchmarkSnapshotJson);
+            writeMetadata(metadata, now);
+        } catch (Exception e) {
+            NozhConstants.LOGGER.warn("Failed to export benchmark artifacts: {}", e.getMessage());
+        } finally {
+            snapshotSeries.clear();
+            activeScenario = null;
+            scenarioStartMillis = 0L;
+        }
+    }
+
+    private void captureSnapshot() {
+        PerfSnapshot snapshot = snapshotSupplier.get();
+        if (snapshot == null) {
+            return;
+        }
+        snapshotSeries.addSnapshot(snapshot);
+    }
+
+    private Path resolveSessionDir() {
+        String timestamp = TIMESTAMP_FORMAT.format(Instant.now());
+        Path dir = rootDir.resolve("session_" + timestamp);
+        try {
+            Files.createDirectories(dir);
+        } catch (Exception e) {
+            NozhConstants.LOGGER.warn("Failed to create benchmark session directory: {}", e.getMessage());
+        }
+        return dir;
+    }
+
+    private void writeMatrixSnapshot() {
+        if (sessionDir == null) {
+            return;
+        }
+        try {
+            BenchmarkMatrix matrix = BenchmarkMatrix.defaultMatrix();
+            Path outputFile = sessionDir.resolve("benchmark_matrix.json");
+            Files.writeString(outputFile, matrix.toJson(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            NozhConstants.LOGGER.warn("Failed to write benchmark matrix: {}", e.getMessage());
+        }
+    }
+
+    private void writeMetadata(BenchmarkArtifactMetadata metadata, long now) throws Exception {
+        Objects.requireNonNull(sessionDir, "sessionDir");
+        String timestamp = TIMESTAMP_FORMAT.format(Instant.ofEpochMilli(now));
+        String scenarioName = metadata.scenario().toLowerCase();
+        Path outputFile = sessionDir.resolve("metadata_" + scenarioName + "_" + timestamp + ".json");
+        Files.writeString(outputFile, metadata.toJson(), StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/dev/nozh/core/benchmark/BenchmarkSnapshotSeries.java
+++ b/src/main/java/dev/nozh/core/benchmark/BenchmarkSnapshotSeries.java
@@ -1,0 +1,75 @@
+package dev.nozh.core.benchmark;
+
+import dev.nozh.api.PerfSnapshot;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Captures a series of perf snapshots during a scenario.
+ */
+public final class BenchmarkSnapshotSeries {
+
+    private final List<PerfSnapshot> snapshots = new ArrayList<>();
+
+    public void addSnapshot(PerfSnapshot snapshot) {
+        if (snapshot == null || snapshot.sampleCount() <= 0) {
+            return;
+        }
+        snapshots.add(snapshot);
+    }
+
+    public boolean isEmpty() {
+        return snapshots.isEmpty();
+    }
+
+    public int size() {
+        return snapshots.size();
+    }
+
+    public void clear() {
+        snapshots.clear();
+    }
+
+    public Path writeJson(Path outputFile) throws Exception {
+        Files.writeString(outputFile, toJson(), StandardCharsets.UTF_8);
+        return outputFile;
+    }
+
+    private String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"samples\": [\n");
+        for (int i = 0; i < snapshots.size(); i++) {
+            PerfSnapshot snapshot = snapshots.get(i);
+            sb.append("    {\n");
+            sb.append("      \"timestampMillis\": ").append(snapshot.timestampMillis()).append(",\n");
+            sb.append("      \"avgFrametimeMs\": ").append(formatMetric(snapshot.avgFrametimeMs())).append(",\n");
+            sb.append("      \"p95FrametimeMs\": ").append(formatMetric(snapshot.p95FrametimeMs())).append(",\n");
+            sb.append("      \"p99FrametimeMs\": ").append(formatMetric(snapshot.p99FrametimeMs())).append(",\n");
+            sb.append("      \"frametimeStddevMs\": ").append(formatMetric(snapshot.frametimeStddevMs())).append(",\n");
+            sb.append("      \"spikeCount\": ").append(snapshot.spikeCount()).append(",\n");
+            sb.append("      \"sampleCount\": ").append(snapshot.sampleCount()).append(",\n");
+            sb.append("      \"windowSeconds\": ").append(snapshot.windowSeconds()).append("\n");
+            sb.append("    }");
+            if (i < snapshots.size() - 1) {
+                sb.append(',');
+            }
+            sb.append('\n');
+        }
+        sb.append("  ]\n");
+        sb.append("}\n");
+        return sb.toString();
+    }
+
+    private String formatMetric(double value) {
+        if (!Double.isFinite(value)) {
+            return "\"--\"";
+        }
+        return String.format("%.3f", value);
+    }
+
+}

--- a/src/main/java/dev/nozh/core/benchmark/InitialBenchmarkRunner.java
+++ b/src/main/java/dev/nozh/core/benchmark/InitialBenchmarkRunner.java
@@ -5,6 +5,7 @@ import dev.nozh.api.PerfSnapshot;
 import dev.nozh.core.state.StateStore;
 import dev.nozh.core.telemetry.TelemetrySnapshot;
 
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -17,6 +18,7 @@ public final class InitialBenchmarkRunner {
 
     private final StateStore stateStore;
     private final Supplier<PerfSnapshot> snapshotSupplier;
+    private final Consumer<PerfSnapshot> snapshotConsumer;
 
     private boolean sessionActive = false;
     private boolean benchmarkStarted = false;
@@ -25,8 +27,14 @@ public final class InitialBenchmarkRunner {
     private long benchmarkStartMillis = 0L;
 
     public InitialBenchmarkRunner(StateStore stateStore, Supplier<PerfSnapshot> snapshotSupplier) {
+        this(stateStore, snapshotSupplier, null);
+    }
+
+    public InitialBenchmarkRunner(StateStore stateStore, Supplier<PerfSnapshot> snapshotSupplier,
+            Consumer<PerfSnapshot> snapshotConsumer) {
         this.stateStore = stateStore;
         this.snapshotSupplier = snapshotSupplier;
+        this.snapshotConsumer = snapshotConsumer;
     }
 
     public void onSessionStart() {
@@ -88,6 +96,9 @@ public final class InitialBenchmarkRunner {
             stateStore.update(s -> s.withBenchmarkStatus(false, benchmarkStartMillis, validity.name()));
         } catch (Exception e) {
             NozhConstants.LOGGER.warn("Failed to finish initial benchmark: {}", e.getMessage());
+        }
+        if (snapshotConsumer != null) {
+            snapshotConsumer.accept(snapshot);
         }
         benchmarkCompleted = true;
     }


### PR DESCRIPTION
### Motivation

- Provide a reproducible benchmark matrix and scenario definitions to cover hardware, resolution, mods and workload cases for comparative analysis.
- Capture an initial calibration benchmark and snapshots during real gameplay sessions for later review.
- Export telemetry in CSV/JSON and persist scenario snapshots so offline analysis and tooling can consume deterministic artifacts.
- Attach environment metadata to each artifact bundle to enable cross-session comparisons.

### Description

- Added benchmark model and helper types: `BenchmarkEnvironment`, `BenchmarkScenario`, `BenchmarkMatrix`, `BenchmarkSnapshotSeries`, and `BenchmarkArtifactMetadata` to describe environments, scenarios and serialized metadata.
- Implemented `BenchmarkScenarioRecorder` to record per-scenario snapshot series, export telemetry via `PerfManager.exportTelemetry(...)`, write snapshot JSON and emit metadata files into `NozhConstants.CONFIG_DIR/benchmark_artifacts`.
- Extended `InitialBenchmarkRunner` to accept an optional `Consumer<PerfSnapshot>` and invoke it when the initial benchmark completes so the recorder can persist the calibration snapshot.
- Wired everything into the client initializer (`NozhModClient`): the recorder is instantiated when `ConfigManager.getConfig().benchmarkModeEnabled` and receives per-tick `tick(...)` calls, plus `onSessionStart`/`onSessionEnd` hooks and an environment builder `buildBenchmarkEnvironment(...)`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc5bd3068832da64ebf1e49429e45)