### PR TITLE
Add release notes and documentation inventory; align docs for v0.2.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased (v0.2.0-alpha)
+
+### Added
+
+* Chaos test CI job with JSON/CSV reporting and report metadata exports.
+* New chaos stress scenarios (entity/chunk/shader) and benchmark scenario artifact recording.
+* Automated modpack quick-test runner and quick-test documentation.
+* Telemetry metrics checklist documentation and architecture freeze policy documentation.
+* First-run tutorial flow with expanded localization coverage.
+
+### Changed
+
+* Strengthened chaos test malicious thresholds and CI reporting behavior.
+
 ## v0.1.0 - "The Foundation" (Golden Master)
 
 **Release Type**: Initial Release

--- a/DESIGN_PHILOSOPHY.md
+++ b/DESIGN_PHILOSOPHY.md
@@ -89,9 +89,8 @@ NOZH es exitoso si el juego se siente más fluido (menos spikes).
 Si NOZH introduce stutter, el diseño ha fallado.
 
 ---
-**ESTADO DEL PROYECTO: GOLDEN MASTER (v0.1.0)**
+**ESTADO DEL PROYECTO: BASE GOLDEN MASTER (v0.1.0) + v0.2.0-alpha en desarrollo**
 
-* Completo.
-* Coherente.
-* Profesional.
+* Base v0.1.0 completa y congelada.
+* Integraciones de v0.2.0-alpha en progreso (preparación beta).
 * Extensible (v0.2.0+) sin reescribir la base.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,15 @@
+# Release Notes
+
+## Unreleased (v0.2.0-alpha)
+
+### Highlights
+- Chaos testing now runs in CI with JSON/CSV reporting and expanded stress scenarios.
+- Benchmarking workflows capture scenario artifacts and richer telemetry exports.
+- First-run tutorial flow and expanded localization coverage.
+- Automated quick-test runners and new documentation on telemetry metrics and architecture freeze policy.
+
+### Breaking Changes
+- None identified for this alpha.
+
+### Upgrade Notes
+- No migration steps required. Existing `config/nozh/state.json` data remains compatible.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,18 @@
 # NOZH Roadmap
 
-## v0.1.0 (Current) - " The Foundation"
+## v0.2.0-alpha (Current) - "The Analyst" (Alpha)
+
+* **Status**: En desarrollo activo (pre-beta)
+* **Focus**: Validación de estabilidad, telemetría ampliada y preparación de suites de prueba.
+* **Delivered**:
+  * Chaos tests en CI con reportes JSON/CSV y metadatos.
+  * Escenarios de caos adicionales (entity/chunk/shader).
+  * Benchmark artifacts por escenario y matriz de benchmark exportable.
+  * Runners de quick-test para modpacks + documentación asociada.
+  * Tutorial inicial y expansión de localizaciones.
+  * Política de freeze de arquitectura documentada.
+
+## v0.1.0 (Released) - "The Foundation"
 
 * **Status**: Released / RC (IMPLEMENTADO)
 * **Features/Phases Completed**:
@@ -14,7 +26,7 @@
 
 > **Contract**: Closed phases (0–6.5) are considered architecturally frozen in v0.x releases. New functionality must extend the system, not rewrite it.
 
-## v0.2.0 - "The Analyst" (Planificado)
+## v0.2.0-beta - "The Analyst" (Planificado)
 
 * **Status**: Planificado (NO implementado aún)
 * **Goal**: Distinguish CPU vs GPU bottlenecks accurately.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ The "Hands" of the system.
 If the mod crashes or fails strictly, it enters **Safe Mode**.
 
 * **Effect**: All Governor/Executor logic is strictly bypassed.
-* **Persistence**: Stored in `nozh-state.json`. Requires user intervention or strict stability check to reset.
+* **Persistence**: Stored in `config/nozh/state.json`. Requires user intervention or strict stability check to reset.
 
 ## Core Architecture Freeze
 
@@ -75,7 +75,7 @@ The following interfaces are considered stable and part of the frozen core contr
 
 * **APIs**: `SimulationGovernor`, `StandardActionExecutor`, `ExecutorGuard`, `FrameTimeSampler`, `RollingWindowStats`.
 * **Events**: `WorldRenderEvents.END` frametime sampling hook.
-* **Data Contracts**: `PerfSnapshot`, `Decision`, `ActionType`, and `nozh-state.json` persistence format.
+* **Data Contracts**: `PerfSnapshot`, `Decision`, `ActionType`, and `state.json` persistence format.
 
 ### Change Process (Deprecations & Versioning)
 
@@ -95,4 +95,4 @@ In NOZH, **Frametime** is the wall-clock time elapsed between two consecutive `W
 `UNKNOWN` is not an error state; it is a valid and important informational state. It means the profiler is warming up or data is insufficient.
 
 ---
-*Document updated for v0.1.0 Release.*
+*Document updated for v0.2.0-alpha.*

--- a/docs/DOCUMENTATION_INVENTORY.md
+++ b/docs/DOCUMENTATION_INVENTORY.md
@@ -1,0 +1,26 @@
+# Inventario de documentación
+
+## Raíz del repositorio
+
+- `README.md` — Visión general del proyecto, instalación, comandos y FAQ.
+- `CHANGELOG.md` — Historial de cambios por versión.
+- `RELEASE_NOTES.md` — Notas de versión resumidas por release.
+- `ROADMAP.md` — Plan de versiones y fases.
+- `DESIGN_PHILOSOPHY.md` — Contrato de diseño y principios de estabilidad.
+- `CONFIG.md` — Guía de configuración.
+- `CONTRIBUTING.md` — Guía de contribución.
+- `LICENSE` — Licencia del proyecto.
+
+## Carpeta `docs/`
+
+- `docs/ARCHITECTURE.md` — Arquitectura y política de compatibilidad.
+- `docs/automated-quick-test.md` — Procedimientos de quick tests automatizados.
+- `docs/benchmarking-methodology.md` — Metodología de benchmarking detallada.
+- `docs/benchmarking.md` — Guía práctica de benchmarking.
+- `docs/ci-chaos-benchmarks.md` — Benchmarks y caos en CI.
+- `docs/critical-notes-for-beta.md` — Notas críticas para la integración beta.
+- `docs/manual-validation.md` — Validación manual.
+- `docs/modpack-quick-test.md` — Quick test para modpacks.
+- `docs/technical-debt-audit.md` — Auditoría de deuda técnica.
+- `docs/telemetry-metrics.md` — Checklist de métricas de telemetría.
+- `docs/v0.2-alpha.md` — Documento de referencia de v0.2-alpha.

--- a/docs/v0.2-alpha.md
+++ b/docs/v0.2-alpha.md
@@ -1,8 +1,8 @@
 # NOZH v0.2-alpha Documentation
 
 **Version:** 0.2-alpha  
-**Status:** Feature Complete, Beta-Ready  
-**Date:** 2025-12-31
+**Status:** Alpha en consolidación (pre-beta)  
+**Date:** 2026-01-06
 
 ---
 
@@ -259,8 +259,8 @@ NOZH is an adaptive performance optimization system for Minecraft 1.20.1, consis
 
 ### Export Format
 
-**Location:** `config/nozh/nozh-benchmark.json`  
-**Contains:** avg, p95, p99, spikes, sampleCount, validity, noiseMetric, notes
+**Location:** `config/nozh/benchmark_artifacts/session_<timestamp>/`  
+**Contains:** `benchmark_matrix.json`, `metadata_<scenario>_<timestamp>.json`, telemetry CSV/JSON exports, y snapshots por escenario
 
 ---
 
@@ -335,7 +335,7 @@ NOZH is an adaptive performance optimization system for Minecraft 1.20.1, consis
 **Solution:**
 
 1. Check `/nozh selfcheck` for critical issues
-2. Review `config/nozh/nozh-state.json` for crash count
+2. Review `config/nozh/state.json` for crash count
 3. Use `/nozh safemode reset` after resolving root cause
 
 ### Provider Degraded/Broken


### PR DESCRIPTION
### Motivation

- Provide a concise `RELEASE_NOTES.md` and a single-source documentation inventory to improve discoverability and release communication.
- Reflect the current development state by promoting the v0.2.0-alpha cycle in user-facing docs and the roadmap.
- Align documentation with code/config semantics (paths, benchmark artifact locations, and state file naming) to avoid confusion.
- Surface recent additions (chaos CI, benchmark artifacts, quick-test runners, tutorial/localization) in the changelog and release notes.

### Description

- Added `RELEASE_NOTES.md` with highlights, breaking changes, and upgrade notes for the `v0.2.0-alpha` cycle. 
- Added `docs/DOCUMENTATION_INVENTORY.md` enumerating key top-level docs and `docs/` contents. 
- Updated `CHANGELOG.md`, `ROADMAP.md`, and `DESIGN_PHILOSOPHY.md` to advertise the alpha work and mark `v0.2.0-alpha` as the current development focus. 
- Corrected documentation references and export locations such as `state.json` path to `config/nozh/state.json` and benchmark artifacts to `config/nozh/benchmark_artifacts/session_<timestamp>/` across `docs/ARCHITECTURE.md` and `docs/v0.2-alpha.md`.

### Testing

- No automated tests were run because this change set is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc8005c58832db8ef5c738b222568)