### PR TITLE
Add scenario coverage metrics to benchmarking docs

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -78,7 +78,27 @@ For each run, capture:
 - **NOZH config** (notably thresholds + target FPS)
 - **Any deviations** from the methodology
 
-## 4) Results Template (Table + Graphs)
+## 4) Scenario Coverage Metrics
+
+Use these metrics to summarize how much of the critical scenario set was executed and how many runs met the success threshold.
+
+**Definitions**
+- **Coverage %** = (critical scenarios executed / total critical scenarios) * 100.
+- **Pass %** = (critical scenarios with P95/P99 within threshold / critical scenarios executed) * 100.
+
+**Success threshold**
+- Use the **target FPS** and **frametime thresholds** defined in the NOZH config/policy when available.
+- If no explicit threshold is defined, treat a scenario as **pass** when **both P95 and P99 are <= 1.5x target frametime** (ms).
+
+**Example table**
+
+| scenario | executed (Y/N) | pass/fail | p95 | p99 | notes |
+| --- | --- | --- | --- | --- | --- |
+| Combat (mobs) | Y | pass | 14.2 | 17.8 | Within 1.5x target frametime |
+| Redstone | Y | fail | 18.5 | 26.1 | P99 exceeded threshold |
+| Megabase | N | n/a | -- | -- | Not run in this cycle |
+
+## 5) Results Template (Table + Graphs)
 
 > Replace placeholders with actual measurements. If multiple runs are performed, report **mean** and **std dev** per scenario.
 
@@ -108,7 +128,7 @@ xychart-beta
 1. Export CSV with columns: `scenario, avg_ms, p95_ms, p99_ms`.
 2. Generate chart using spreadsheet or plotting tool.
 
-## 5) Variability + Limits
+## 6) Variability + Limits
 
 Include a short note that captures:
 - **Run-to-run variance** (std dev or range) and potential causes (GC, background load).


### PR DESCRIPTION
### Motivation
- Provide a standardized way to report how many critical benchmarking scenarios were executed and how many met pass criteria.
- Define clear metrics so coverage and success are comparable across runs and reports.
- Offer guidance to use existing NOZH config/policy thresholds when available, with a sensible default when not.
- Give a concrete example table to make adoption easy for test authors.

### Description
- Updated `docs/benchmarking.md` to add a new "Scenario Coverage Metrics" section with definitions for `Coverage %` and `Pass %`.
- Added success threshold guidance that references NOZH config/policy and a default rule that both P95 and P99 must be `<= 1.5x target frametime` when no explicit threshold exists.
- Inserted an example coverage table with columns `scenario`, `executed (Y/N)`, `pass/fail`, `p95`, `p99`, and `notes`.
- Renumbered downstream sections so `Results Template` is now section 5 and `Variability + Limits` is section 6.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dcfb4dab8832d8b6e99f982294c2e)