### PR TITLE
Add observability indicators tooling and documentation

### DIFF
--- a/docs/observability-reporting.md
+++ b/docs/observability-reporting.md
@@ -1,0 +1,93 @@
+# Observabilidad y reporting (crash-free + compatibilidad)
+
+Este documento define el stack actual de observabilidad, los dashboards requeridos y los jobs automáticos para generar
+indicadores de crash-free y compatibilidad.
+
+## 1) Stack actual de observabilidad/reporting
+
+**Fuentes internas (NOZH):**
+- **Exportaciones de telemetría**: CSV/JSON generados por `TelemetryExportWriter` mediante
+  `/nozh telemetry export csv|json` en `config/nozh/telemetry_exports/`.
+- **Telemetría agregada**: reportes Markdown/JSON a partir del `TelemetryReportGenerator` (uso interno y tooling).
+- **Estado de crash loop**: `config/nozh/state.json` (boot attempts, safe mode, último contexto de fallo).
+- **Compatibilidad**: `CompatMatrix` calcula conflictos y score de compatibilidad en runtime (vía `/nozh selfcheck`).
+- **Logs**: `config/nozh/nozh-debug.log` cuando `debugLogs=true`.
+
+**Stack externo (actual):**
+- No hay integración nativa con Grafana/Kibana/Sentry. La observabilidad se realiza con exports locales
+  y herramientas en `tools/` para convertirlas en reportes o indicadores.
+
+## 2) Dashboards recomendados
+
+### 2.1 Crash-free
+
+**KPI:** `crash_free_percent` (0% o 100% en el estado actual del cliente).
+
+**Fuente de datos:** `config/nozh/state.json`.
+
+**Reglas de cálculo:**
+- Crash loop detectado si `safeModeCauses` incluye `CRASH_LOOP` **o** (`bootAttempts >= 3` y `sessionStable == false`).
+- `crash_free_percent = 0` si hay crash loop; `100` si no lo hay.
+
+**Campos adicionales:**
+- `safe_mode_active`, `safe_mode_causes`, `last_failure_context`.
+
+### 2.2 Compatibilidad
+
+**KPI:** `compat_score` (0–100).
+
+**Fuente de datos:** export de `/nozh selfcheck` (JSON recomendado) o snapshot de compatibilidad generado
+por tooling (ver job automático).
+
+**Campos adicionales:**
+- `conflict_count`, `loaded_mods`, `recommendations`.
+
+## 3) Jobs automáticos
+
+Los siguientes jobs generan indicadores en intervalos definidos y publican resultados en `reports/`:
+
+### 3.1 Indicadores de crash-free + compatibilidad
+
+Comando:
+
+```bash
+python3 tools/observability_indicators.py \
+  --state-file config/nozh/state.json \
+  --compat-file config/nozh/compat_report.json \
+  --output reports/observability_indicators.json
+```
+
+Frecuencia sugerida:
+- **Cada 15 minutos** para entornos activos (staging/qa/prod).
+
+### 3.2 Reporte de telemetría (performance)
+
+Comando:
+
+```bash
+python3 tools/telemetry_report.py \
+  --input config/nozh/telemetry_exports \
+  --output reports/telemetry_report.md
+```
+
+Frecuencia sugerida:
+- **Cada 60 minutos** o al final de una sesión de benchmark.
+
+### 3.3 Ejemplo de cron
+
+```
+*/15 * * * * /usr/bin/python3 /path/to/repo/tools/observability_indicators.py --state-file /path/to/config/nozh/state.json --compat-file /path/to/config/nozh/compat_report.json --output /path/to/repo/reports/observability_indicators.json
+0 * * * * /usr/bin/python3 /path/to/repo/tools/telemetry_report.py --input /path/to/config/nozh/telemetry_exports --output /path/to/repo/reports/telemetry_report.md
+```
+
+## 4) Acceso, fuente de datos y frecuencia
+
+| Indicador | Fuente | Acceso | Frecuencia |
+| --- | --- | --- | --- |
+| crash_free_percent | `config/nozh/state.json` | Archivo local en cliente/instancia | 15 min |
+| safe_mode_* | `config/nozh/state.json` | Archivo local en cliente/instancia | 15 min |
+| compat_score | `/nozh selfcheck` ➜ `compat_report.json` | Archivo local exportado | 15 min |
+| conflict_count | `/nozh selfcheck` ➜ `compat_report.json` | Archivo local exportado | 15 min |
+| telemetry_report | `config/nozh/telemetry_exports/` | Export CSV/JSON | 60 min |
+
+> Nota: si el entorno no puede exportar `compat_report.json`, el job de indicadores reportará `compat_score=null`.

--- a/tools/observability_indicators.py
+++ b/tools/observability_indicators.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CrashFreeIndicator:
+    crash_free_percent: float
+    crash_loop_detected: bool
+    safe_mode_active: bool
+    safe_mode_causes: list[str] | None
+    boot_attempts: int | None
+    session_stable: bool | None
+    last_failure_context: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class CompatibilityIndicator:
+    compat_score: float | None
+    conflict_count: int | None
+    loaded_mods: int | None
+    recommendations: list[str] | None
+
+
+@dataclass(frozen=True)
+class ObservabilityIndicators:
+    generated_at: str
+    crash_free: CrashFreeIndicator
+    compatibility: CompatibilityIndicator
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compute crash-free and compatibility indicators for observability dashboards."
+    )
+    parser.add_argument(
+        "--state-file",
+        type=Path,
+        default=Path("config/nozh/state.json"),
+        help="Path to state.json",
+    )
+    parser.add_argument(
+        "--compat-file",
+        type=Path,
+        default=Path("config/nozh/compat_report.json"),
+        help="Path to compatibility report JSON",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("reports/observability_indicators.json"),
+        help="Output JSON path",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def detect_crash_loop(state: dict[str, Any]) -> bool:
+    safe_mode_causes = state.get("safeModeCauses") or []
+    boot_attempts = state.get("bootAttempts", 0)
+    session_stable = state.get("sessionStable", False)
+    return "CRASH_LOOP" in safe_mode_causes or (boot_attempts >= 3 and not session_stable)
+
+
+def build_crash_free_indicator(state: dict[str, Any] | None) -> CrashFreeIndicator:
+    if not state:
+        return CrashFreeIndicator(
+            crash_free_percent=100.0,
+            crash_loop_detected=False,
+            safe_mode_active=False,
+            safe_mode_causes=None,
+            boot_attempts=None,
+            session_stable=None,
+            last_failure_context=None,
+        )
+    crash_loop_detected = detect_crash_loop(state)
+    crash_free_percent = 0.0 if crash_loop_detected else 100.0
+    return CrashFreeIndicator(
+        crash_free_percent=crash_free_percent,
+        crash_loop_detected=crash_loop_detected,
+        safe_mode_active=bool(state.get("safeModeCauses")),
+        safe_mode_causes=state.get("safeModeCauses"),
+        boot_attempts=state.get("bootAttempts"),
+        session_stable=state.get("sessionStable"),
+        last_failure_context=state.get("lastFailureContext"),
+    )
+
+
+def extract_compat_score(payload: dict[str, Any]) -> float | None:
+    for key in ("compatScore", "compatibilityScore", "score"):
+        value = payload.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+    return None
+
+
+def build_compat_indicator(compat: dict[str, Any] | None) -> CompatibilityIndicator:
+    if not compat:
+        return CompatibilityIndicator(
+            compat_score=None,
+            conflict_count=None,
+            loaded_mods=None,
+            recommendations=None,
+        )
+    conflicts = compat.get("conflicts")
+    loaded_mods = compat.get("loadedMods")
+    recommendations = compat.get("recommendations")
+    return CompatibilityIndicator(
+        compat_score=extract_compat_score(compat),
+        conflict_count=len(conflicts) if isinstance(conflicts, list) else None,
+        loaded_mods=len(loaded_mods) if isinstance(loaded_mods, list) else None,
+        recommendations=recommendations if isinstance(recommendations, list) else None,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    state = load_json(args.state_file)
+    compat = load_json(args.compat_file)
+
+    indicators = ObservabilityIndicators(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        crash_free=build_crash_free_indicator(state),
+        compatibility=build_compat_indicator(compat),
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(asdict(indicators), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide an operational path to measure crash-free and compatibility KPIs and to publish them for dashboards without requiring an external observability stack.  
- Make it easy to run periodic jobs that compute and export indicators from local NOZH state and compatibility outputs.  

### Description
- Add `docs/observability-reporting.md` documenting the current observability sources, recommended dashboards (`crash_free_percent`, `compat_score`), calculation rules, job examples, and cadence.  
- Add `tools/observability_indicators.py` that reads `config/nozh/state.json` and an optional `config/nozh/compat_report.json` and writes `reports/observability_indicators.json` with crash-free and compatibility indicators.  
- Implement crash-loop detection in the script using the rule: `CRASH_LOOP` present in `safeModeCauses` or `(bootAttempts >= 3 && !sessionStable)`, and expose `safe_mode_causes` in the indicator payload.  
- Update documentation to reflect the `safe_mode_causes` field and example cron jobs to run the jobs periodically.  

### Testing
- No automated tests were executed for this change (documentation and small tooling script only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dcfe75834832d81aea207300ac160)