### PR TITLE
Governor decision budget, latency profiling, and ActionMatrix scoring with p95/spike impacts

### DIFF
--- a/src/main/java/dev/nozh/core/benchmark/BenchmarkArtifactMetadata.java
+++ b/src/main/java/dev/nozh/core/benchmark/BenchmarkArtifactMetadata.java
@@ -14,7 +14,8 @@ public record BenchmarkArtifactMetadata(
         Path telemetryCsv,
         Path telemetryJson,
         Path snapshotsJson,
-        Path initialBenchmarkSnapshotJson) {
+        Path initialBenchmarkSnapshotJson,
+        Path decisionLatencyJson) {
 
     public String toJson() {
         StringBuilder sb = new StringBuilder();
@@ -26,7 +27,8 @@ public record BenchmarkArtifactMetadata(
         sb.append("  \"telemetryCsv\": ").append(formatPath(telemetryCsv)).append(",\n");
         sb.append("  \"telemetryJson\": ").append(formatPath(telemetryJson)).append(",\n");
         sb.append("  \"snapshotsJson\": ").append(formatPath(snapshotsJson)).append(",\n");
-        sb.append("  \"initialBenchmarkSnapshotJson\": ").append(formatPath(initialBenchmarkSnapshotJson)).append("\n");
+        sb.append("  \"initialBenchmarkSnapshotJson\": ").append(formatPath(initialBenchmarkSnapshotJson)).append(",\n");
+        sb.append("  \"decisionLatencyJson\": ").append(formatPath(decisionLatencyJson)).append("\n");
         sb.append("}\n");
         return sb.toString();
     }

--- a/src/main/java/dev/nozh/core/benchmark/BenchmarkScenarioRecorder.java
+++ b/src/main/java/dev/nozh/core/benchmark/BenchmarkScenarioRecorder.java
@@ -3,6 +3,7 @@ package dev.nozh.core.benchmark;
 import dev.nozh.NozhConstants;
 import dev.nozh.api.PerfSnapshot;
 import dev.nozh.core.context.Scenario;
+import dev.nozh.core.profiler.DecisionLatencyStats;
 import dev.nozh.core.profiler.PerfManager;
 import dev.nozh.core.telemetry.TelemetryExportFormat;
 
@@ -108,6 +109,7 @@ public final class BenchmarkScenarioRecorder {
             TelemetryExportFormat[] formats = {TelemetryExportFormat.CSV, TelemetryExportFormat.JSON};
             Path csv = null;
             Path json = null;
+            Path decisionLatencyJson = null;
             for (TelemetryExportFormat format : formats) {
                 Path export = perfManager != null ? perfManager.exportTelemetry(sessionDir, format) : null;
                 if (format == TelemetryExportFormat.CSV) {
@@ -123,6 +125,12 @@ public final class BenchmarkScenarioRecorder {
                         + "_" + timestamp + ".json");
                 snapshotSeries.writeJson(snapshotsJson);
             }
+            if (perfManager != null) {
+                DecisionLatencyStats stats = perfManager.getDecisionLatencyStats();
+                String timestamp = TIMESTAMP_FORMAT.format(Instant.ofEpochMilli(now));
+                decisionLatencyJson = sessionDir.resolve("decision_latency_" + timestamp + ".json");
+                Files.writeString(decisionLatencyJson, stats.toJson(), StandardCharsets.UTF_8);
+            }
             BenchmarkArtifactMetadata metadata = new BenchmarkArtifactMetadata(
                     environment,
                     activeScenario.name(),
@@ -131,7 +139,8 @@ public final class BenchmarkScenarioRecorder {
                     csv,
                     json,
                     snapshotsJson,
-                    initialBenchmarkSnapshotJson);
+                    initialBenchmarkSnapshotJson,
+                    decisionLatencyJson);
             writeMetadata(metadata, now);
         } catch (Exception e) {
             NozhConstants.LOGGER.warn("Failed to export benchmark artifacts: {}", e.getMessage());

--- a/src/main/java/dev/nozh/core/governor/DecisionBudget.java
+++ b/src/main/java/dev/nozh/core/governor/DecisionBudget.java
@@ -1,0 +1,25 @@
+package dev.nozh.core.governor;
+
+import java.util.concurrent.TimeUnit;
+
+public final class DecisionBudget {
+
+    private final long startNanos;
+    private final long budgetNanos;
+
+    public DecisionBudget(int budgetMs) {
+        this.startNanos = System.nanoTime();
+        this.budgetNanos = TimeUnit.MILLISECONDS.toNanos(Math.max(0, budgetMs));
+    }
+
+    public boolean isOverBudget() {
+        if (budgetNanos <= 0) {
+            return true;
+        }
+        return System.nanoTime() - startNanos > budgetNanos;
+    }
+
+    public long elapsedMs() {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+    }
+}

--- a/src/main/java/dev/nozh/core/governor/GovernorRunner.java
+++ b/src/main/java/dev/nozh/core/governor/GovernorRunner.java
@@ -51,6 +51,7 @@ public final class GovernorRunner {
     private static final int MAX_SUGGESTED_QUEUE = 5;
     private static final int REVERSE_IMPROVEMENT_STREAK = 3;
     private static final long SPIKE_PREDICTION_MIN_WINDOW_MS = 5_000L;
+    private static final int DECISION_LATENCY_TARGET_MS = 2;
 
     private final HybridGovernor governor;
     private final ActionMatrix actionMatrix;
@@ -237,6 +238,8 @@ public final class GovernorRunner {
             return;
         }
 
+        int decisionBudgetMs = Math.min(config.governorDecisionBudgetMs, DECISION_LATENCY_TARGET_MS);
+        DecisionBudget decisionBudget = new DecisionBudget(decisionBudgetMs);
         long decisionStartNanos = perfManager != null ? perfManager.startDecisionTimer() : System.nanoTime();
         Optional<ActionCandidate> decisionOpt = governor.decide(
                 state,
@@ -250,10 +253,20 @@ public final class GovernorRunner {
                 state.baselineSnapshot(),
                 state.currentSettings(),
                 config,
-                actionMatrixTuning);
+                actionMatrixTuning,
+                decisionBudget);
 
-        if (perfManager != null && !perfManager.isDecisionWithinBudget(decisionStartNanos,
-                config.governorDecisionBudgetMs)) {
+        if (decisionBudget.isOverBudget()) {
+            if (perfManager != null) {
+                perfManager.recordDecisionLatency(decisionStartNanos);
+            }
+            logger.warn(String.format(
+                    "Governor decision aborted - internal budget exceeded (%dms)",
+                    decisionBudget.elapsedMs()));
+            return;
+        }
+
+        if (perfManager != null && !perfManager.isDecisionWithinBudget(decisionStartNanos, decisionBudgetMs)) {
             logger.warn(String.format(
                     "Governor decision aborted - latency budget exceeded (%dms)",
                     perfManager.getLastDecisionLatencyMs()));
@@ -808,7 +821,7 @@ public final class GovernorRunner {
                             logger.warn("Safe fallback rollback failed");
                         }
                     }), () -> logger.warn("Safe fallback rollback unavailable"));
-            sessionLearning.recordOutcome(pending.capability(), pending.scenario(), ActionOutcome.NEGATIVE, 0.0);
+            sessionLearning.recordOutcome(pending.capability(), pending.scenario(), ActionOutcome.NEGATIVE, 0.0, 0.0, 0);
             successTracker.recordFailure(pending.capability());
             try {
                 stateStore.update(RuntimeState::withPendingActionCleared);
@@ -857,16 +870,18 @@ public final class GovernorRunner {
                 logger.info("Rollback disabled in config, keeping ineffective action.");
             }
 
-            sessionLearning.recordOutcome(pending.capability(), pending.scenario(), ActionOutcome.NEGATIVE, 0.0);
+            sessionLearning.recordOutcome(pending.capability(), pending.scenario(), ActionOutcome.NEGATIVE, 0.0,
+                    p95Delta, spikeDelta);
             successTracker.recordFailure(pending.capability());
         } else if (outcome == ActionOutcome.POSITIVE) {
             double gainAvg = resolveGain(pending.baselineAvgMs(), currentSnapshot != null ? currentSnapshot.avgFrametimeMs() : Double.NaN);
             double gainP95 = resolveGain(pending.baselineP95Ms(), currentSnapshot != null ? currentSnapshot.p95FrametimeMs() : Double.NaN);
             sessionLearning.recordOutcome(pending.capability(), pending.scenario(), ActionOutcome.POSITIVE,
-                    Math.max(gainAvg, gainP95));
+                    Math.max(gainAvg, gainP95), p95Delta, spikeDelta);
             successTracker.recordSuccess(pending.capability());
         } else {
-            sessionLearning.recordOutcome(pending.capability(), pending.scenario(), ActionOutcome.NEUTRAL, 0.0);
+            sessionLearning.recordOutcome(pending.capability(), pending.scenario(), ActionOutcome.NEUTRAL, 0.0,
+                    p95Delta, spikeDelta);
         }
 
         logger.debug(String.format(

--- a/src/main/java/dev/nozh/core/governor/HybridGovernor.java
+++ b/src/main/java/dev/nozh/core/governor/HybridGovernor.java
@@ -34,7 +34,8 @@ public final class HybridGovernor {
             dev.nozh.core.state.BaselineSnapshot baselineSnapshot,
             Map<dev.nozh.core.bus.CapabilityId, dev.nozh.core.bus.CapabilityValue> currentSettings,
             NozhConfig config,
-            ActionMatrixTuning tuning) {
+            ActionMatrixTuning tuning,
+            DecisionBudget budget) {
         Optional<ActionCandidate> candidate = rulesGovernor.decide(
                 state,
                 mode,
@@ -46,7 +47,8 @@ public final class HybridGovernor {
                 reverseReady,
                 baselineSnapshot,
                 currentSettings,
-                tuning);
+                tuning,
+                budget);
         if (candidate.isEmpty()) {
             return candidate;
         }
@@ -74,6 +76,23 @@ public final class HybridGovernor {
             return Optional.empty();
         }
         return candidate;
+    }
+
+    public Optional<ActionCandidate> decide(
+            RuntimeState state,
+            GovernorMode mode,
+            String currentBound,
+            long nowMillis,
+            OptimizationProfile profile,
+            int targetFps,
+            double reverseEpsilonMs,
+            boolean reverseReady,
+            dev.nozh.core.state.BaselineSnapshot baselineSnapshot,
+            Map<dev.nozh.core.bus.CapabilityId, dev.nozh.core.bus.CapabilityValue> currentSettings,
+            NozhConfig config,
+            ActionMatrixTuning tuning) {
+        return decide(state, mode, currentBound, nowMillis, profile, targetFps, reverseEpsilonMs, reverseReady,
+                baselineSnapshot, currentSettings, config, tuning, null);
     }
 
     public boolean canAct(RuntimeState state, long lastActionTimestamp, long nowMillis, boolean benchmarkMode,

--- a/src/main/java/dev/nozh/core/governor/SimulationGovernor.java
+++ b/src/main/java/dev/nozh/core/governor/SimulationGovernor.java
@@ -88,7 +88,8 @@ public final class SimulationGovernor {
                         boolean reverseReady,
                         dev.nozh.core.state.BaselineSnapshot baselineSnapshot,
                         Map<dev.nozh.core.bus.CapabilityId, dev.nozh.core.bus.CapabilityValue> currentSettings,
-                        ActionMatrixTuning tuning) {
+                        ActionMatrixTuning tuning,
+                        DecisionBudget budget) {
                 // OFF mode → no decisions
                 if (mode == GovernorMode.OFF) {
                         return Optional.empty();
@@ -107,7 +108,8 @@ public final class SimulationGovernor {
                                         profile,
                                         baselineSnapshot,
                                         currentSettings,
-                                        tuning);
+                                        tuning,
+                                        budget);
                         if (!reverseCandidates.isEmpty()) {
                                 return Optional.of(reverseCandidates.get(0));
                         }
@@ -120,7 +122,8 @@ public final class SimulationGovernor {
                                 profile,
                                 state.p95FrametimeMs(),
                                 state.spikeCount(),
-                                tuning);
+                                tuning,
+                                budget);
 
                 if (candidates.isEmpty()) {
                         return Optional.empty();
@@ -128,6 +131,22 @@ public final class SimulationGovernor {
 
                 // Return best candidate (already sorted by ActionMatrix)
                 return Optional.of(candidates.get(0));
+        }
+
+        public Optional<ActionCandidate> decide(
+                        RuntimeState state,
+                        GovernorMode mode,
+                        String currentBound,
+                        long nowMillis,
+                        OptimizationProfile profile,
+                        int targetFps,
+                        double reverseEpsilonMs,
+                        boolean reverseReady,
+                        dev.nozh.core.state.BaselineSnapshot baselineSnapshot,
+                        Map<dev.nozh.core.bus.CapabilityId, dev.nozh.core.bus.CapabilityValue> currentSettings,
+                        ActionMatrixTuning tuning) {
+                return decide(state, mode, currentBound, nowMillis, profile, targetFps, reverseEpsilonMs, reverseReady,
+                                baselineSnapshot, currentSettings, tuning, null);
         }
 
         private boolean shouldReverseOptimize(

--- a/src/main/java/dev/nozh/core/intelligence/SessionLearning.java
+++ b/src/main/java/dev/nozh/core/intelligence/SessionLearning.java
@@ -94,6 +94,11 @@ public final class SessionLearning {
 
     public void recordOutcome(CapabilityId id, dev.nozh.core.context.Scenario scenario, ActionOutcome outcome,
             double fpsGainMs) {
+        recordOutcome(id, scenario, outcome, fpsGainMs, 0.0, 0);
+    }
+
+    public void recordOutcome(CapabilityId id, dev.nozh.core.context.Scenario scenario, ActionOutcome outcome,
+            double fpsGainMs, double p95DeltaMs, int spikeDelta) {
         String key = buildKey(id, scenario);
         ActionStats stats = history.computeIfAbsent(key, k -> new ActionStats());
 
@@ -109,6 +114,10 @@ public final class SessionLearning {
         } else {
             stats.neutralCount++;
         }
+        stats.totalP95DeltaMs += p95DeltaMs;
+        stats.avgP95DeltaMs = stats.totalP95DeltaMs / stats.totalAttempts;
+        stats.totalSpikeDelta += spikeDelta;
+        stats.avgSpikeDelta = (double) stats.totalSpikeDelta / stats.totalAttempts;
         dirty = true;
     }
 
@@ -170,6 +179,19 @@ public final class SessionLearning {
     public double getAvgFpsGain(CapabilityId id, dev.nozh.core.context.Scenario scenario) {
         ActionStats stats = history.get(buildKey(id, scenario));
         return stats != null ? stats.avgFpsGain : 0.0;
+    }
+
+    public double getAvgP95Gain(CapabilityId id, dev.nozh.core.context.Scenario scenario) {
+        ActionStats stats = history.get(buildKey(id, scenario));
+        if (stats == null) {
+            return 0.0;
+        }
+        return Math.max(0.0, -stats.avgP95DeltaMs);
+    }
+
+    public double getAvgSpikeDelta(CapabilityId id, dev.nozh.core.context.Scenario scenario) {
+        ActionStats stats = history.get(buildKey(id, scenario));
+        return stats != null ? stats.avgSpikeDelta : 0.0;
     }
 
     /**
@@ -392,6 +414,10 @@ public final class SessionLearning {
         public long lastFailureTime = 0;
         public double totalFpsGain = 0.0;
         public double avgFpsGain = 0.0;
+        public double totalP95DeltaMs = 0.0;
+        public double avgP95DeltaMs = 0.0;
+        public int totalSpikeDelta = 0;
+        public double avgSpikeDelta = 0.0;
     }
 
     public static class PredictionStats {

--- a/src/main/java/dev/nozh/core/matrix/ActionMatrix.java
+++ b/src/main/java/dev/nozh/core/matrix/ActionMatrix.java
@@ -9,6 +9,7 @@ import dev.nozh.core.capability.ProviderRegistry;
 import dev.nozh.core.capability.ProviderStatus;
 import dev.nozh.core.capability.SafetyLevel;
 import dev.nozh.core.context.Scenario;
+import dev.nozh.core.governor.DecisionBudget;
 import dev.nozh.core.governor.ModePolicy;
 import dev.nozh.core.governor.OptimizationProfile;
 
@@ -36,6 +37,8 @@ public final class ActionMatrix {
     private static final double LEARNED_RANKING_WEIGHT = 0.2;
     private static final double LEARNED_SUCCESS_WEIGHT = 0.1;
     private static final double LEARNED_GAIN_WEIGHT = 0.1;
+    private static final double REAL_GAIN_WEIGHT = 0.15;
+    private static final double SPIKE_PENALTY_WEIGHT = 0.2;
     private static final double SCENARIO_PRIORITY_WEIGHT = 0.15;
     private static final double PERFORMANCE_PRESSURE_WEIGHT = 0.25;
     private static final double BASELINE_FRAME_MS = 16.67;
@@ -108,14 +111,18 @@ public final class ActionMatrix {
             OptimizationProfile profile,
             double p95FrametimeMs,
             int spikeCount,
-            ActionMatrixTuning tuning) {
+            ActionMatrixTuning tuning,
+            DecisionBudget budget) {
         List<ActionCandidate> candidates = new ArrayList<>();
-        List<ActionCandidate> yieldCandidates = new ArrayList<>();
+        ActionCandidate yieldCandidate = null;
         long now = System.currentTimeMillis();
         ActionMatrixTuning resolvedTuning = tuning != null ? tuning : ActionMatrixTuning.defaults();
 
         // Iterate all registered providers
         for (CapabilityProvider provider : registry.getAllProviders()) {
+            if (budget != null && budget.isOverBudget()) {
+                return List.of();
+            }
             CapabilityId id = provider.id();
             ProviderMetadata metadata = provider.metadata();
 
@@ -138,8 +145,10 @@ public final class ActionMatrix {
             }
 
             if (compatibilityMatrix != null && compatibilityMatrix.isBlockedByDependencies(metadata)) {
-                yieldCandidates.add(ActionCandidate.yield(id,
-                        compatibilityMatrix.getDependencySteward(metadata)));
+                if (yieldCandidate == null) {
+                    yieldCandidate = ActionCandidate.yield(id,
+                            compatibilityMatrix.getDependencySteward(metadata));
+                }
                 continue;
             }
 
@@ -181,7 +190,9 @@ public final class ActionMatrix {
             // INTEGRATION: Conflict Detection
             if (compatibilityMatrix != null && compatibilityMatrix.isExternallyManaged(id, metadata)) {
                 // If another mod handles this, we should not touch it
-                yieldCandidates.add(ActionCandidate.yield(id, compatibilityMatrix.getSteward(id)));
+                if (yieldCandidate == null) {
+                    yieldCandidate = ActionCandidate.yield(id, compatibilityMatrix.getSteward(id));
+                }
                 continue;
             }
 
@@ -217,31 +228,43 @@ public final class ActionMatrix {
             candidates.add(candidate);
         }
 
+        if (budget != null && budget.isOverBudget()) {
+            return List.of();
+        }
+
         // Sort by weighted score (descending)
-        double maxExpectedGain = candidates.stream()
-                .mapToDouble(ActionCandidate::expectedGainMs)
-                .max()
-                .orElse(0.0);
+        double maxExpectedGain = 0.0;
+        double maxRanking = 0.0;
+        double maxLearnedGain = 0.0;
+        double maxP95Gain = 0.0;
+        double maxSpikePenalty = 0.0;
+        for (ActionCandidate candidate : candidates) {
+            maxExpectedGain = Math.max(maxExpectedGain, candidate.expectedGainMs());
+            double ranking = sessionLearning.getRanking(candidate.capabilityId(), scenario);
+            maxRanking = Math.max(maxRanking, ranking);
+            double learnedGain = sessionLearning.getAvgFpsGain(candidate.capabilityId(), scenario);
+            maxLearnedGain = Math.max(maxLearnedGain, learnedGain);
+            double p95Gain = sessionLearning.getAvgP95Gain(candidate.capabilityId(), scenario);
+            maxP95Gain = Math.max(maxP95Gain, p95Gain);
+            double spikePenalty = Math.max(0.0, sessionLearning.getAvgSpikeDelta(candidate.capabilityId(), scenario));
+            maxSpikePenalty = Math.max(maxSpikePenalty, spikePenalty);
+        }
 
-        double maxRanking = candidates.stream()
-                .mapToDouble(candidate -> sessionLearning.getRanking(candidate.capabilityId(), scenario))
-                .max()
-                .orElse(0.0);
-
-        double maxLearnedGain = candidates.stream()
-                .mapToDouble(candidate -> sessionLearning.getAvgFpsGain(candidate.capabilityId(), scenario))
-                .max()
-                .orElse(0.0);
+        final double maxExpectedGainFinal = maxExpectedGain;
+        final double maxRankingFinal = maxRanking;
+        final double maxLearnedGainFinal = maxLearnedGain;
+        final double maxP95GainFinal = maxP95Gain;
+        final double maxSpikePenaltyFinal = maxSpikePenalty;
 
         ActionSelectionContext selectionContext = new ActionSelectionContext(scenario, profile, p95FrametimeMs,
                 spikeCount, resolvedTuning);
         candidates.sort(Comparator
-                .comparingDouble((ActionCandidate candidate) -> scoreCandidate(candidate, maxExpectedGain, maxRanking,
-                        maxLearnedGain, selectionContext))
+                .comparingDouble((ActionCandidate candidate) -> scoreCandidate(candidate, maxExpectedGainFinal,
+                        maxRankingFinal, maxLearnedGainFinal, maxP95GainFinal, maxSpikePenaltyFinal, selectionContext))
                 .reversed());
 
-        if (candidates.isEmpty() && !yieldCandidates.isEmpty()) {
-            return List.of(yieldCandidates.get(0));
+        if (candidates.isEmpty() && yieldCandidate != null) {
+            return List.of(yieldCandidate);
         }
 
         return candidates;
@@ -255,7 +278,19 @@ public final class ActionMatrix {
             double p95FrametimeMs,
             int spikeCount) {
         return generateCandidates(policy, currentBound, scenario, profile, p95FrametimeMs, spikeCount,
-                ActionMatrixTuning.defaults());
+                ActionMatrixTuning.defaults(), null);
+    }
+
+    public List<ActionCandidate> generateCandidates(
+            ModePolicy policy,
+            String currentBound,
+            Scenario scenario,
+            OptimizationProfile profile,
+            double p95FrametimeMs,
+            int spikeCount,
+            ActionMatrixTuning tuning) {
+        return generateCandidates(policy, currentBound, scenario, profile, p95FrametimeMs, spikeCount,
+                tuning, null);
     }
 
     public List<ActionCandidate> generateReverseCandidates(
@@ -264,7 +299,8 @@ public final class ActionMatrix {
             OptimizationProfile profile,
             dev.nozh.core.state.BaselineSnapshot baselineSnapshot,
             Map<CapabilityId, CapabilityValue> currentSettings,
-            ActionMatrixTuning tuning) {
+            ActionMatrixTuning tuning,
+            DecisionBudget budget) {
         List<ActionCandidate> candidates = new ArrayList<>();
         if (baselineSnapshot == null || baselineSnapshot.isEmpty()) {
             return candidates;
@@ -273,6 +309,9 @@ public final class ActionMatrix {
         ActionMatrixTuning resolvedTuning = tuning != null ? tuning : ActionMatrixTuning.defaults();
 
         for (CapabilityProvider provider : registry.getAllProviders()) {
+            if (budget != null && budget.isOverBudget()) {
+                return List.of();
+            }
             CapabilityId id = provider.id();
             ProviderMetadata metadata = provider.metadata();
 
@@ -346,7 +385,18 @@ public final class ActionMatrix {
             dev.nozh.core.state.BaselineSnapshot baselineSnapshot,
             Map<CapabilityId, CapabilityValue> currentSettings) {
         return generateReverseCandidates(policy, scenario, profile, baselineSnapshot, currentSettings,
-                ActionMatrixTuning.defaults());
+                ActionMatrixTuning.defaults(), null);
+    }
+
+    public List<ActionCandidate> generateReverseCandidates(
+            ModePolicy policy,
+            Scenario scenario,
+            OptimizationProfile profile,
+            dev.nozh.core.state.BaselineSnapshot baselineSnapshot,
+            Map<CapabilityId, CapabilityValue> currentSettings,
+            ActionMatrixTuning tuning) {
+        return generateReverseCandidates(policy, scenario, profile, baselineSnapshot, currentSettings,
+                tuning, null);
     }
 
     private int determineTier(ProviderMetadata metadata) {
@@ -576,13 +626,17 @@ public final class ActionMatrix {
     }
 
     private double scoreCandidate(ActionCandidate candidate, double maxExpectedGain, double maxRanking,
-            double maxLearnedGain, ActionSelectionContext context) {
+            double maxLearnedGain, double maxP95Gain, double maxSpikePenalty, ActionSelectionContext context) {
         double normalizedGain = maxExpectedGain > 0 ? candidate.expectedGainMs() / maxExpectedGain : 0.0;
         double ranking = sessionLearning.getRanking(candidate.capabilityId(), context.scenario());
         double normalizedRanking = maxRanking > 0 ? ranking / maxRanking : 0.0;
         double learnedSuccess = sessionLearning.getSuccessRate(candidate.capabilityId(), context.scenario());
         double learnedGain = sessionLearning.getAvgFpsGain(candidate.capabilityId(), context.scenario());
         double normalizedLearnedGain = maxLearnedGain > 0 ? learnedGain / maxLearnedGain : 0.0;
+        double p95Gain = sessionLearning.getAvgP95Gain(candidate.capabilityId(), context.scenario());
+        double normalizedP95Gain = maxP95Gain > 0 ? p95Gain / maxP95Gain : 0.0;
+        double spikePenalty = Math.max(0.0, sessionLearning.getAvgSpikeDelta(candidate.capabilityId(), context.scenario()));
+        double normalizedSpikePenalty = maxSpikePenalty > 0 ? spikePenalty / maxSpikePenalty : 0.0;
         double scenarioBoost = scenarioRules.ruleWeight(candidate.capabilityId(), context.scenario(),
                 context.profile()) * context.tuning().scenarioWeightMultiplier();
         double pressure = calculatePerformancePressure(context.p95FrametimeMs(), context.spikeCount())
@@ -596,9 +650,11 @@ public final class ActionMatrix {
                 + (normalizedRanking * LEARNED_RANKING_WEIGHT)
                 + (learnedSuccess * LEARNED_SUCCESS_WEIGHT)
                 + (normalizedLearnedGain * LEARNED_GAIN_WEIGHT)
+                + (normalizedP95Gain * REAL_GAIN_WEIGHT)
                 + (scenarioBoost * SCENARIO_PRIORITY_WEIGHT);
 
-        return baseScore + (pressure * profilePressureWeight * (normalizedGain + scenarioBoost) / 2.0);
+        double score = baseScore + (pressure * profilePressureWeight * (normalizedGain + scenarioBoost) / 2.0);
+        return score - (normalizedSpikePenalty * SPIKE_PENALTY_WEIGHT);
     }
 
     private double blendConfidence(double baseConfidence, double learnedConfidence) {

--- a/src/main/java/dev/nozh/core/profiler/DecisionLatencyEvaluator.java
+++ b/src/main/java/dev/nozh/core/profiler/DecisionLatencyEvaluator.java
@@ -5,19 +5,35 @@ import java.util.concurrent.TimeUnit;
 public final class DecisionLatencyEvaluator {
 
     private long lastDecisionLatencyMs = -1L;
+    private long maxDecisionLatencyMs = 0L;
+    private long totalDecisionLatencyMs = 0L;
+    private long decisionCount = 0L;
 
     public long startTimer() {
         return System.nanoTime();
     }
 
-    public boolean isWithinBudget(long startNanos, int budgetMs) {
+    public long recordLatency(long startNanos) {
         long elapsedNanos = System.nanoTime() - startNanos;
         long elapsedMs = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
         lastDecisionLatencyMs = elapsedMs;
+        maxDecisionLatencyMs = Math.max(maxDecisionLatencyMs, elapsedMs);
+        totalDecisionLatencyMs += elapsedMs;
+        decisionCount++;
+        return elapsedMs;
+    }
+
+    public boolean isWithinBudget(long startNanos, int budgetMs) {
+        long elapsedMs = recordLatency(startNanos);
         return elapsedMs <= budgetMs;
     }
 
     public long getLastDecisionLatencyMs() {
         return lastDecisionLatencyMs;
+    }
+
+    public DecisionLatencyStats snapshot() {
+        double avgMs = decisionCount > 0 ? (double) totalDecisionLatencyMs / decisionCount : 0.0;
+        return new DecisionLatencyStats(decisionCount, avgMs, maxDecisionLatencyMs, lastDecisionLatencyMs);
     }
 }

--- a/src/main/java/dev/nozh/core/profiler/DecisionLatencyStats.java
+++ b/src/main/java/dev/nozh/core/profiler/DecisionLatencyStats.java
@@ -1,0 +1,19 @@
+package dev.nozh.core.profiler;
+
+public record DecisionLatencyStats(
+        long decisionCount,
+        double avgLatencyMs,
+        long maxLatencyMs,
+        long lastLatencyMs) {
+
+    public String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"decisionCount\": ").append(decisionCount).append(",\n");
+        sb.append("  \"avgLatencyMs\": ").append(String.format("%.2f", avgLatencyMs)).append(",\n");
+        sb.append("  \"maxLatencyMs\": ").append(maxLatencyMs).append(",\n");
+        sb.append("  \"lastLatencyMs\": ").append(lastLatencyMs).append("\n");
+        sb.append("}\n");
+        return sb.toString();
+    }
+}

--- a/src/main/java/dev/nozh/core/profiler/PerfManager.java
+++ b/src/main/java/dev/nozh/core/profiler/PerfManager.java
@@ -137,12 +137,20 @@ public class PerfManager {
         return decisionLatencyEvaluator.startTimer();
     }
 
+    public void recordDecisionLatency(long startNanos) {
+        decisionLatencyEvaluator.recordLatency(startNanos);
+    }
+
     public boolean isDecisionWithinBudget(long startNanos, int budgetMs) {
         return decisionLatencyEvaluator.isWithinBudget(startNanos, budgetMs);
     }
 
     public long getLastDecisionLatencyMs() {
         return decisionLatencyEvaluator.getLastDecisionLatencyMs();
+    }
+
+    public DecisionLatencyStats getDecisionLatencyStats() {
+        return decisionLatencyEvaluator.snapshot();
     }
 
     public void onRenderPhaseStart(RenderPhase phase) {

--- a/src/test/java/dev/nozh/core/matrix/ActionMatrixTest.java
+++ b/src/test/java/dev/nozh/core/matrix/ActionMatrixTest.java
@@ -18,6 +18,7 @@ import dev.nozh.core.governor.ModePolicy;
 import dev.nozh.core.governor.OptimizationProfile;
 import dev.nozh.core.intelligence.SessionLearning;
 import dev.nozh.core.state.BaselineSnapshot;
+import dev.nozh.core.governor.ActionOutcome;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -191,6 +192,32 @@ class ActionMatrixTest {
         assertEquals(CapabilityId.CLOUDS, candidates.get(0).capabilityId());
         assertEquals(RollbackGuarantee.BEST_EFFORT, candidates.get(0).rollbackGuarantee());
         assertEquals(RollbackGuarantee.STRONG, candidates.get(1).rollbackGuarantee());
+    }
+
+    @Test
+    void spikePenaltyDemotesNoisyActions() {
+        ProviderMetadata cloudsMetadata = metadata(ImpactLevel.LOW, ImpactLevel.LOW, SafetyLevel.SAFE, 2.0);
+        ProviderMetadata particlesMetadata = metadata(ImpactLevel.LOW, ImpactLevel.LOW, SafetyLevel.SAFE, 2.0);
+        ProviderRegistry registry = registryWith(
+                provider(CapabilityId.CLOUDS, cloudsMetadata),
+                provider(CapabilityId.PARTICLES, particlesMetadata));
+
+        ActionSuccessTracker tracker = successTrackerWith(CapabilityId.CLOUDS, CapabilityId.PARTICLES);
+        SessionLearning learning = new SessionLearning(tempDir.toFile());
+        learning.recordOutcome(CapabilityId.CLOUDS, Scenario.STANDARD, ActionOutcome.POSITIVE, 2.0, -0.8, 0);
+        learning.recordOutcome(CapabilityId.PARTICLES, Scenario.STANDARD, ActionOutcome.POSITIVE, 2.0, -0.8, 3);
+
+        ActionMatrix matrix = new ActionMatrix(
+                registry,
+                tracker,
+                new ConfidenceCalculator(),
+                learning);
+
+        List<ActionCandidate> candidates = matrix.generateCandidates(ModePolicy.manualAssist(), "BALANCED",
+                Scenario.STANDARD, OptimizationProfile.BALANCED, 20.0, 2);
+
+        assertEquals(2, candidates.size());
+        assertEquals(CapabilityId.CLOUDS, candidates.get(0).capabilityId());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Reduce governor decision latency and enforce an internal budget to keep decision work <2ms.
- Improve decision quality by integrating real frametime (p95) and spike impact into cost/benefit scoring.
- Measure internal overhead (decision latency) and export it alongside benchmark artifacts.
- Provide telemetry-driven scoring penalties for noisy actions to avoid unstable changes.

### Description

- Added a lightweight `DecisionBudget` applied to the governor and `ActionMatrix` to abort candidate generation when the internal budget is exceeded, and wired a 2ms target into `GovernorRunner` (`DECISION_LATENCY_TARGET_MS`).
- Extended session learning with p95 and spike metrics by adding overloaded `recordOutcome(...)` and storing `totalP95DeltaMs`/`avgP95DeltaMs` and `totalSpikeDelta`/`avgSpikeDelta`, plus accessors `getAvgP95Gain` and `getAvgSpikeDelta` for scoring.
- Incorporated real p95 gain and spike-penalty into `ActionMatrix` scoring with new weights (`REAL_GAIN_WEIGHT`, `SPIKE_PENALTY_WEIGHT`) and made `ActionMatrix` accept a `DecisionBudget` to cut off work when needed.
- Added decision-latency profiling: enhanced `DecisionLatencyEvaluator` to record/aggregate latencies, new `DecisionLatencyStats` type, `PerfManager` hooks to record latencies, and benchmark export of `decision_latency_*.json` via `BenchmarkScenarioRecorder` and metadata update in `BenchmarkArtifactMetadata`.
- Adapted governor layers (`SimulationGovernor`, `HybridGovernor`, `GovernorRunner`) to propagate the `DecisionBudget` and to record p95/spike deltas into session learning when evaluating pending actions.
- Added a unit test `spikePenaltyDemotesNoisyActions` to validate that noisy actions are demoted by the new spike penalty in `ActionMatrixTest`.

### Testing

- Ran the module tests with `./gradlew test --tests dev.nozh.core.matrix.ActionMatrixTest` which exercised `ActionMatrix` behavior and the new `spikePenaltyDemotesNoisyActions` test; build failed to complete due to external test dependency downloads returning HTTP 403 (network repository access blocked).
- Project compiled locally during the rollout and the new code was type-checked, but full test execution could not finish because of the blocked dependency resolution. 
- No runtime regressions were observed in static compile-time checks; additional CI/integration runs are recommended after resolving repository access to confirm behavioral changes end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd4468294832da8c5d2ba29df646c)