### PR TITLE
Add delayed causal spike analysis and persist causality in SessionLearning

### DIFF
--- a/src/main/java/dev/nozh/core/governor/GovernorRunner.java
+++ b/src/main/java/dev/nozh/core/governor/GovernorRunner.java
@@ -693,7 +693,18 @@ public final class GovernorRunner {
             return SpikeCausalityReport.unknown();
         }
         SpikeCausalityReport report = perfManager.getSpikeCausality();
-        return report != null ? report : SpikeCausalityReport.unknown();
+        if (report == null) {
+            return SpikeCausalityReport.unknown();
+        }
+        if (sessionLearning != null && report.cause() != null) {
+            double learnedConfidence = sessionLearning.getCausalityConfidence(report.cause());
+            if (learnedConfidence > 0.0 && report.confidence() > 0.0) {
+                double blended = Math.min(0.95, report.confidence() * 0.7 + learnedConfidence * 0.3);
+                report = new SpikeCausalityReport(report.cause(), blended, report.detail());
+            }
+            sessionLearning.recordCausality(report.cause(), report.confidence());
+        }
+        return report;
     }
 
     private String applyCausalityBound(String detectedBound, SpikeCausalityReport report) {

--- a/src/main/java/dev/nozh/core/intelligence/SessionLearning.java
+++ b/src/main/java/dev/nozh/core/intelligence/SessionLearning.java
@@ -3,6 +3,7 @@ package dev.nozh.core.intelligence;
 import dev.nozh.core.bus.CapabilityId;
 import dev.nozh.NozhConstants;
 import dev.nozh.core.governor.ActionOutcome;
+import dev.nozh.core.profiler.SpikeCauseType;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -17,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,6 +42,7 @@ public final class SessionLearning {
     private static final String DEFAULT_SESSION_KEY = "DEFAULT";
     private final Map<String, ActionStats> history = new HashMap<>();
     private final PredictionStats predictionStats = new PredictionStats();
+    private final Map<SpikeCauseType, CausalityStats> causalityHistory = new EnumMap<>(SpikeCauseType.class);
     private final File statsFile;
     private final Path statsPath;
     private final Path tmpPath;
@@ -63,6 +66,7 @@ public final class SessionLearning {
         sessionKey = normalizedKey;
         history.clear();
         predictionStats.reset();
+        causalityHistory.clear();
         lastSavedHash = 0;
         lastSaveMillis = 0;
         dirty = true;
@@ -150,6 +154,23 @@ public final class SessionLearning {
 
     public int getPredictionCount() {
         return predictionStats.totalPredictions;
+    }
+
+    public void recordCausality(SpikeCauseType cause, double confidence) {
+        if (cause == null || cause == SpikeCauseType.UNKNOWN) {
+            return;
+        }
+        CausalityStats stats = causalityHistory.computeIfAbsent(cause, key -> new CausalityStats());
+        stats.totalCount++;
+        stats.totalConfidence += Math.max(0.0, confidence);
+        stats.avgConfidence = stats.totalCount > 0 ? stats.totalConfidence / stats.totalCount : 0.0;
+        stats.lastObservedMillis = System.currentTimeMillis();
+        dirty = true;
+    }
+
+    public double getCausalityConfidence(SpikeCauseType cause) {
+        CausalityStats stats = causalityHistory.get(cause);
+        return stats != null ? stats.avgConfidence : 0.0;
     }
 
     /**
@@ -288,7 +309,7 @@ public final class SessionLearning {
                 parent.mkdirs();
             }
 
-            String json = GSON.toJson(new SessionData(sessionKey, history, predictionStats));
+            String json = GSON.toJson(new SessionData(sessionKey, history, predictionStats, causalityHistory));
             int currentHash = json.hashCode();
             if (!force && currentHash == lastSavedHash) {
                 dirty = false;
@@ -324,7 +345,7 @@ public final class SessionLearning {
             }
 
             try {
-                String json = GSON.toJson(new SessionData(sessionKey, history, predictionStats));
+                String json = GSON.toJson(new SessionData(sessionKey, history, predictionStats, causalityHistory));
                 Files.writeString(statsPath, json, StandardCharsets.UTF_8,
                         StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
             } catch (IOException ignored) {
@@ -356,6 +377,9 @@ public final class SessionLearning {
                         if (data.predictionStats != null) {
                             predictionStats.copyFrom(data.predictionStats);
                         }
+                        if (data.causalityHistory != null) {
+                            causalityHistory.putAll(data.causalityHistory);
+                        }
                     }
                 } else {
                     java.lang.reflect.Type type = new com.google.gson.reflect.TypeToken<Map<String, ActionStats>>() {
@@ -374,7 +398,8 @@ public final class SessionLearning {
                 }
             }
 
-            lastSavedHash = GSON.toJson(new SessionData(sessionKey, history, predictionStats)).hashCode();
+            lastSavedHash = GSON.toJson(new SessionData(sessionKey, history, predictionStats, causalityHistory))
+                    .hashCode();
             lastSaveMillis = System.currentTimeMillis();
             safeLog("Session learning loaded ({} entries)", history.size());
         } catch (Exception e) {
@@ -453,15 +478,25 @@ public final class SessionLearning {
         }
     }
 
+    public static class CausalityStats {
+        public int totalCount = 0;
+        public double totalConfidence = 0.0;
+        public double avgConfidence = 0.0;
+        public long lastObservedMillis = 0;
+    }
+
     private static final class SessionData {
         public String sessionKey;
         public Map<String, ActionStats> history;
         public PredictionStats predictionStats;
+        public Map<SpikeCauseType, CausalityStats> causalityHistory;
 
-        private SessionData(String sessionKey, Map<String, ActionStats> history, PredictionStats predictionStats) {
+        private SessionData(String sessionKey, Map<String, ActionStats> history, PredictionStats predictionStats,
+                Map<SpikeCauseType, CausalityStats> causalityHistory) {
             this.sessionKey = sessionKey;
             this.history = history;
             this.predictionStats = predictionStats;
+            this.causalityHistory = causalityHistory;
         }
     }
 }

--- a/src/main/java/dev/nozh/core/profiler/CausalAnalyzer.java
+++ b/src/main/java/dev/nozh/core/profiler/CausalAnalyzer.java
@@ -1,0 +1,212 @@
+package dev.nozh.core.profiler;
+
+import dev.nozh.api.PerfSnapshot;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CausalAnalyzer {
+
+    private static final int[] LAG_SECONDS = { 1, 2, 3 };
+    private static final int MAX_SECONDS = 12;
+    private static final double MIN_CORRELATION = 0.25;
+
+    private final SpikeCausalityAnalyzer immediateAnalyzer = new SpikeCausalityAnalyzer();
+    private final Map<Long, CausalSample> samples = new LinkedHashMap<>();
+    private int lastSpikeCount = -1;
+
+    public SpikeCausalityReport analyze(PerfSnapshot frameSnapshot,
+            PerfSnapshot tickSnapshot,
+            GcMetricsSnapshot gcMetrics,
+            FramePauseSnapshot pauses,
+            RenderPipelineSnapshot renderSnapshot,
+            PerfTraceSnapshot traceSnapshot) {
+        SpikeCausalityReport immediate = immediateAnalyzer.analyze(frameSnapshot, tickSnapshot, gcMetrics,
+                pauses, renderSnapshot, traceSnapshot);
+
+        updateSamples(frameSnapshot, tickSnapshot, gcMetrics, pauses, renderSnapshot);
+
+        CausalityScore delayed = resolveDelayedCause();
+        if (delayed != null && delayed.confidence > immediate.confidence()) {
+            return new SpikeCausalityReport(delayed.cause, delayed.confidence, delayed.detail);
+        }
+        return immediate != null ? immediate : SpikeCausalityReport.unknown();
+    }
+
+    public void reset() {
+        samples.clear();
+        lastSpikeCount = -1;
+    }
+
+    private void updateSamples(PerfSnapshot frameSnapshot,
+            PerfSnapshot tickSnapshot,
+            GcMetricsSnapshot gcMetrics,
+            FramePauseSnapshot pauses,
+            RenderPipelineSnapshot renderSnapshot) {
+        long nowSeconds = System.currentTimeMillis() / 1000L;
+        int spikeDelta = resolveSpikeDelta(frameSnapshot);
+        double gcMs = gcMetrics != null ? gcMetrics.recentGcMs() : 0.0;
+        double tickP95 = tickSnapshot != null ? tickSnapshot.p95FrametimeMs() : 0.0;
+        double renderMax = 0.0;
+        if (renderSnapshot != null && renderSnapshot.hottestPhase() != null) {
+            renderMax = renderSnapshot.hottestPhase().maxMs();
+        }
+        double frameP95 = frameSnapshot != null ? frameSnapshot.p95FrametimeMs() : 0.0;
+        double pauseMax = pauses != null ? pauses.maxPauseMs() : 0.0;
+
+        CausalSample sample = samples.get(nowSeconds);
+        if (sample == null) {
+            sample = new CausalSample(nowSeconds);
+            samples.put(nowSeconds, sample);
+        }
+        sample.update(spikeDelta, gcMs, tickP95, renderMax, frameP95, pauseMax);
+        pruneOld(nowSeconds);
+    }
+
+    private int resolveSpikeDelta(PerfSnapshot snapshot) {
+        if (snapshot == null) {
+            return 0;
+        }
+        int current = snapshot.spikeCount();
+        int delta = 0;
+        if (lastSpikeCount >= 0) {
+            delta = Math.max(0, current - lastSpikeCount);
+        }
+        lastSpikeCount = current;
+        return delta;
+    }
+
+    private void pruneOld(long nowSeconds) {
+        long cutoff = nowSeconds - MAX_SECONDS;
+        List<Long> toRemove = new ArrayList<>();
+        for (Long second : samples.keySet()) {
+            if (second < cutoff) {
+                toRemove.add(second);
+            } else {
+                break;
+            }
+        }
+        for (Long second : toRemove) {
+            samples.remove(second);
+        }
+    }
+
+    private CausalityScore resolveDelayedCause() {
+        CausalityScore best = null;
+        for (SpikeCauseType cause : new SpikeCauseType[] { SpikeCauseType.GC, SpikeCauseType.TICK,
+                SpikeCauseType.RENDER, SpikeCauseType.FRAME }) {
+            for (int lag : LAG_SECONDS) {
+                double correlation = calculateCorrelation(cause, lag);
+                if (correlation <= MIN_CORRELATION) {
+                    continue;
+                }
+                double confidence = Math.min(0.95, 0.25 + 0.7 * correlation);
+                String detail = String.format("lag %ds corr %.2f", lag, correlation);
+                if (best == null || confidence > best.confidence) {
+                    best = new CausalityScore(cause, confidence, detail);
+                }
+            }
+        }
+        return best;
+    }
+
+    private double calculateCorrelation(SpikeCauseType cause, int lagSeconds) {
+        if (samples.size() < 4) {
+            return 0.0;
+        }
+        List<Double> metrics = new ArrayList<>();
+        List<Double> spikes = new ArrayList<>();
+        for (Map.Entry<Long, CausalSample> entry : samples.entrySet()) {
+            long second = entry.getKey();
+            CausalSample spikeSample = entry.getValue();
+            CausalSample metricSample = samples.get(second - lagSeconds);
+            if (metricSample == null) {
+                continue;
+            }
+            metrics.add(metricSample.metricForCause(cause));
+            spikes.add((double) spikeSample.spikeDelta);
+        }
+        if (metrics.size() < 3) {
+            return 0.0;
+        }
+        return Math.max(0.0, pearson(metrics, spikes));
+    }
+
+    private double pearson(List<Double> xs, List<Double> ys) {
+        int size = xs.size();
+        if (size == 0 || size != ys.size()) {
+            return 0.0;
+        }
+        double meanX = 0.0;
+        double meanY = 0.0;
+        for (int i = 0; i < size; i++) {
+            meanX += xs.get(i);
+            meanY += ys.get(i);
+        }
+        meanX /= size;
+        meanY /= size;
+        double numerator = 0.0;
+        double sumSqX = 0.0;
+        double sumSqY = 0.0;
+        for (int i = 0; i < size; i++) {
+            double dx = xs.get(i) - meanX;
+            double dy = ys.get(i) - meanY;
+            numerator += dx * dy;
+            sumSqX += dx * dx;
+            sumSqY += dy * dy;
+        }
+        double denominator = Math.sqrt(sumSqX * sumSqY);
+        if (denominator <= 0.0) {
+            return 0.0;
+        }
+        return numerator / denominator;
+    }
+
+    private static final class CausalSample {
+        private final long second;
+        private int spikeDelta;
+        private double gcMs;
+        private double tickP95;
+        private double renderMax;
+        private double frameP95;
+        private double pauseMax;
+
+        private CausalSample(long second) {
+            this.second = second;
+        }
+
+        private void update(int spikeDelta, double gcMs, double tickP95, double renderMax, double frameP95,
+                double pauseMax) {
+            this.spikeDelta += spikeDelta;
+            this.gcMs = Math.max(this.gcMs, gcMs);
+            this.tickP95 = Math.max(this.tickP95, tickP95);
+            this.renderMax = Math.max(this.renderMax, renderMax);
+            this.frameP95 = Math.max(this.frameP95, frameP95);
+            this.pauseMax = Math.max(this.pauseMax, pauseMax);
+        }
+
+        private double metricForCause(SpikeCauseType cause) {
+            return switch (cause) {
+                case GC -> gcMs;
+                case TICK -> tickP95;
+                case RENDER -> renderMax;
+                case FRAME -> Math.max(frameP95, pauseMax);
+                case CRITICAL_EVENT, UNKNOWN -> 0.0;
+            };
+        }
+    }
+
+    private static final class CausalityScore {
+        private final SpikeCauseType cause;
+        private final double confidence;
+        private final String detail;
+
+        private CausalityScore(SpikeCauseType cause, double confidence, String detail) {
+            this.cause = cause;
+            this.confidence = confidence;
+            this.detail = detail;
+        }
+    }
+}

--- a/src/main/java/dev/nozh/core/profiler/PerfManager.java
+++ b/src/main/java/dev/nozh/core/profiler/PerfManager.java
@@ -36,7 +36,7 @@ public class PerfManager implements CriticalEventSink {
     private final FramePauseTracker pauseTracker;
     private final RenderPipelineTracer renderPipelineTracer;
     private final StutterCauseAnalyzer stutterCauseAnalyzer;
-    private final SpikeCausalityAnalyzer spikeCausalityAnalyzer;
+    private final CausalAnalyzer causalAnalyzer;
     private final PerfTraceBuffer traceBuffer;
     private long lastWindowAdjustMillis = 0L;
     private Supplier<PerfSnapshot> tickSnapshotSupplier = null;
@@ -52,7 +52,7 @@ public class PerfManager implements CriticalEventSink {
         this.pauseTracker = new FramePauseTracker();
         this.renderPipelineTracer = new RenderPipelineTracer();
         this.stutterCauseAnalyzer = new StutterCauseAnalyzer();
-        this.spikeCausalityAnalyzer = new SpikeCausalityAnalyzer();
+        this.causalAnalyzer = new CausalAnalyzer();
         this.traceBuffer = new PerfTraceBuffer();
 
         int targetFps = Math.max(30, config.targetFps);
@@ -115,7 +115,7 @@ public class PerfManager implements CriticalEventSink {
         FramePauseSnapshot pauses = pauseTracker.snapshot();
         RenderPipelineSnapshot renderSnapshot = renderPipelineTracer.snapshot();
         PerfTraceSnapshot traceSnapshot = traceBuffer.snapshot(windowSeconds * 1000L);
-        SpikeCausalityReport spikeCausality = spikeCausalityAnalyzer.analyze(snapshot, tickSnapshot, gcSnapshot,
+        SpikeCausalityReport spikeCausality = causalAnalyzer.analyze(snapshot, tickSnapshot, gcSnapshot,
                 pauses, renderSnapshot, traceSnapshot);
         PerfReport report = new PerfReport(
                 snapshot,
@@ -140,6 +140,7 @@ public class PerfManager implements CriticalEventSink {
         sampler.reset();
         spikePredictor.reset();
         traceBuffer.reset();
+        causalAnalyzer.reset();
     }
 
     public SpikePrediction getSpikePrediction() {
@@ -215,7 +216,7 @@ public class PerfManager implements CriticalEventSink {
         FramePauseSnapshot pauses = pauseTracker.snapshot();
         RenderPipelineSnapshot renderSnapshot = renderPipelineTracer.snapshot();
         PerfTraceSnapshot traceSnapshot = traceBuffer.snapshot(windowSeconds * 1000L);
-        return spikeCausalityAnalyzer.analyze(stats.snapshot(), tickSnapshot, gcSnapshot, pauses, renderSnapshot,
+        return causalAnalyzer.analyze(stats.snapshot(), tickSnapshot, gcSnapshot, pauses, renderSnapshot,
                 traceSnapshot);
     }
 


### PR DESCRIPTION
### Motivation
- Detect not only immediate causes of frametime spikes but also delayed causes that precede spikes by 1–3s. 
- Rank and expose the most likely cause to the governor so decisions favor fixes aligned with root cause. 
- Remember observed causality per machine to improve future decisions. 
- Integrate causality into telemetry and reporting so diagnostics reflect delayed correlations.

### Description
- Adds a new `CausalAnalyzer` that accumulates per-second samples and computes lagged Pearson correlations (1–3s) between spike deltas and profiler metrics to score delayed causes, returning a `SpikeCausalityReport` when delayed confidence exceeds immediate heuristics (`src/main/java/dev/nozh/core/profiler/CausalAnalyzer.java`).
- Wires the analyzer into `PerfManager` (`causalAnalyzer`) so telemetry exports and `getSpikeCausality()` use the delayed analysis and resets clear its state (`src/main/java/dev/nozh/core/profiler/PerfManager.java`).
- Persists causality observations in `SessionLearning` (`causalityHistory`, `recordCausality()`, `getCausalityConfidence()` and JSON save/load) to retain average confidence per `SpikeCauseType` across runs (`src/main/java/dev/nozh/core/intelligence/SessionLearning.java`).
- Blends learned causality confidence into governor decisions in `GovernorRunner.resolveSpikeCausality()` and records new observations back into `SessionLearning` to influence future blending (`src/main/java/dev/nozh/core/governor/GovernorRunner.java`).

### Testing
- No automated tests were executed against these changes during this rollout.
- (Existing unit tests touching `SessionLearning`, `PerfManager`, and governor logic remain unchanged and should be run in CI to validate integration.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5b15bf5c832dbee203841b6c41f1)