### PR TITLE
Optimize hot-path buffers and reduce allocations

### DIFF
--- a/src/main/java/dev/nozh/core/matrix/ActionMatrix.java
+++ b/src/main/java/dev/nozh/core/matrix/ActionMatrix.java
@@ -43,6 +43,9 @@ public final class ActionMatrix {
     private static final double PERFORMANCE_PRESSURE_WEIGHT = 0.25;
     private static final double BASELINE_FRAME_MS = 16.67;
     private static final double MAX_SPIKE_PRESSURE = 5.0;
+    private static final String[] PARTICLE_ORDER = {"MINIMAL", "DECREASED", "ALL"};
+    private static final String[] CLOUD_ORDER = {"OFF", "FAST", "FANCY"};
+    private static final String[] GRAPHICS_ORDER = {"FAST", "FANCY", "FABULOUS"};
 
     private final ProviderRegistry registry;
     private final ActionSuccessTracker successTracker;
@@ -715,9 +718,9 @@ public final class ActionMatrix {
             return false;
         }
         return switch (id) {
-            case PARTICLES -> compareEnum(current, baseline, List.of("MINIMAL", "DECREASED", "ALL"));
-            case CLOUDS -> compareEnum(current, baseline, List.of("OFF", "FAST", "FANCY"));
-            case GRAPHICS_MODE -> compareEnum(current, baseline, List.of("FAST", "FANCY", "FABULOUS"));
+            case PARTICLES -> compareEnum(current, baseline, PARTICLE_ORDER);
+            case CLOUDS -> compareEnum(current, baseline, CLOUD_ORDER);
+            case GRAPHICS_MODE -> compareEnum(current, baseline, GRAPHICS_ORDER);
             case ENTITY_SHADOWS, ARMOR_STANDS, ITEM_FRAMES, BLOCK_ENTITIES, ANIMATIONS, VSYNC, DYNAMIC_LIGHTING ->
                     compareBool(current, baseline);
             case RENDER_DISTANCE, SIMULATION_DISTANCE, ENTITY_DISTANCE, BIOME_BLEND, MIPMAP_LEVEL, FOG ->
@@ -727,17 +730,26 @@ public final class ActionMatrix {
         };
     }
 
-    private boolean compareEnum(CapabilityValue current, CapabilityValue baseline, List<String> ordering) {
+    private boolean compareEnum(CapabilityValue current, CapabilityValue baseline, String[] ordering) {
         if (!(current instanceof CapabilityValue.EnumValue currentEnum)
                 || !(baseline instanceof CapabilityValue.EnumValue baselineEnum)) {
             return false;
         }
-        int currentIndex = ordering.indexOf(currentEnum.name());
-        int baselineIndex = ordering.indexOf(baselineEnum.name());
+        int currentIndex = indexOf(ordering, currentEnum.name());
+        int baselineIndex = indexOf(ordering, baselineEnum.name());
         if (currentIndex < 0 || baselineIndex < 0) {
             return false;
         }
         return baselineIndex > currentIndex;
+    }
+
+    private int indexOf(String[] ordering, String value) {
+        for (int i = 0; i < ordering.length; i++) {
+            if (ordering[i].equals(value)) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private boolean compareBool(CapabilityValue current, CapabilityValue baseline) {

--- a/src/main/java/dev/nozh/core/profiler/GcPauseWatcher.java
+++ b/src/main/java/dev/nozh/core/profiler/GcPauseWatcher.java
@@ -29,11 +29,11 @@ public class GcPauseWatcher {
     /**
      * Update GC tracking. Call periodically (e.g., every tick or every few frames).
      */
-    public java.util.Optional<GcPauseEvent> update() {
+    public GcPauseEvent update() {
         long now = System.currentTimeMillis();
         
         if (now - lastCheckTime < CHECK_INTERVAL_MS) {
-            return java.util.Optional.empty();
+            return null;
         }
         
         long totalTime = getTotalCollectionTime();
@@ -49,10 +49,10 @@ public class GcPauseWatcher {
         
         if (delta > 0) {
             NozhConstants.LOGGER.debug("GC activity: {}ms in last {}ms", delta, elapsed);
-            return java.util.Optional.of(new GcPauseEvent(now, elapsed, delta));
+            return new GcPauseEvent(now, elapsed, delta);
         }
         
-        return java.util.Optional.empty();
+        return null;
     }
     
     /**

--- a/src/main/java/dev/nozh/core/profiler/PerfManager.java
+++ b/src/main/java/dev/nozh/core/profiler/PerfManager.java
@@ -78,10 +78,13 @@ public class PerfManager implements CriticalEventSink {
             // Correcting logic:
             sampler.onFrame();
         }
-        gcPauseWatcher.update().ifPresent(event -> traceBuffer.record(PerfTraceEvent.gc(
-                event.timestampMillis(),
-                event.pauseMs(),
-                String.format("GC %.0fms", event.pauseMs()))));
+        GcPauseEvent event = gcPauseWatcher.update();
+        if (event != null) {
+            traceBuffer.record(PerfTraceEvent.gc(
+                    event.timestampMillis(),
+                    event.pauseMs(),
+                    String.format("GC %.0fms", event.pauseMs())));
+        }
     }
 
     public PerfSnapshot getSnapshot() {

--- a/src/main/java/dev/nozh/core/profiler/PerfTraceBuffer.java
+++ b/src/main/java/dev/nozh/core/profiler/PerfTraceBuffer.java
@@ -1,34 +1,43 @@
 package dev.nozh.core.profiler;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
 
 public class PerfTraceBuffer {
     private static final int MAX_EVENTS = 512;
-    private final Deque<PerfTraceEvent> events = new ArrayDeque<>();
+    private final PerfTraceEvent[] events = new PerfTraceEvent[MAX_EVENTS];
+    private int startIndex = 0;
+    private int size = 0;
 
     public synchronized void record(PerfTraceEvent event) {
         if (event == null) {
             return;
         }
-        events.addLast(event);
-        while (events.size() > MAX_EVENTS) {
-            events.removeFirst();
+        if (size < MAX_EVENTS) {
+            int index = (startIndex + size) % MAX_EVENTS;
+            events[index] = event;
+            size++;
+        } else {
+            events[startIndex] = event;
+            startIndex = (startIndex + 1) % MAX_EVENTS;
         }
     }
 
     public synchronized PerfTraceSnapshot snapshot(long windowMillis) {
-        if (events.isEmpty() || windowMillis <= 0) {
+        if (size == 0 || windowMillis <= 0) {
             return PerfTraceSnapshot.empty();
         }
         long now = System.currentTimeMillis();
         long windowStart = now - windowMillis;
         pruneBefore(windowStart);
-        List<PerfTraceEvent> recent = new ArrayList<>();
-        for (PerfTraceEvent event : events) {
-            if (event.timestampMillis() >= windowStart) {
+        if (size == 0) {
+            return PerfTraceSnapshot.empty();
+        }
+        List<PerfTraceEvent> recent = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            int index = (startIndex + i) % MAX_EVENTS;
+            PerfTraceEvent event = events[index];
+            if (event != null && event.timestampMillis() >= windowStart) {
                 recent.add(event);
             }
         }
@@ -36,16 +45,28 @@ public class PerfTraceBuffer {
     }
 
     public synchronized void reset() {
-        events.clear();
+        for (int i = 0; i < size; i++) {
+            int index = (startIndex + i) % MAX_EVENTS;
+            events[index] = null;
+        }
+        startIndex = 0;
+        size = 0;
     }
 
     private void pruneBefore(long cutoffMillis) {
-        while (!events.isEmpty()) {
-            PerfTraceEvent oldest = events.peekFirst();
+        int removed = 0;
+        while (removed < size) {
+            int index = (startIndex + removed) % MAX_EVENTS;
+            PerfTraceEvent oldest = events[index];
             if (oldest == null || oldest.timestampMillis() >= cutoffMillis) {
                 break;
             }
-            events.removeFirst();
+            events[index] = null;
+            removed++;
+        }
+        if (removed > 0) {
+            startIndex = (startIndex + removed) % MAX_EVENTS;
+            size -= removed;
         }
     }
 }

--- a/src/main/java/dev/nozh/core/telemetry/RingTelemetryBuffer.java
+++ b/src/main/java/dev/nozh/core/telemetry/RingTelemetryBuffer.java
@@ -19,8 +19,9 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
 
     private final TelemetrySample[] buffer;
     private final int capacity;
+    private final double[] frametimeScratch;
 
-    private volatile int writeIndex = 0;
+    private volatile int startIndex = 0;
     private volatile int size = 0;
     private volatile int droppedCount = 0;
 
@@ -32,6 +33,7 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
         }
         this.capacity = capacity;
         this.buffer = new TelemetrySample[capacity];
+        this.frametimeScratch = new double[capacity];
     }
 
     /**
@@ -49,13 +51,13 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
 
         try {
             synchronized (buffer) {
-                buffer[writeIndex] = sample;
-                writeIndex = (writeIndex + 1) % capacity;
-
                 if (size < capacity) {
+                    int index = (startIndex + size) % capacity;
+                    buffer[index] = sample;
                     size++;
                 } else {
-                    // Buffer full, we're dropping oldest (implicit by overwrite)
+                    buffer[startIndex] = sample;
+                    startIndex = (startIndex + 1) % capacity;
                     droppedCount++;
                 }
             }
@@ -67,53 +69,43 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
 
     @Override
     public TelemetrySnapshot snapshot() {
-        TelemetrySample[] copy;
         int currentSize;
         int currentDropped;
+        double sumFrametime = 0;
+        int frametimeSamples = 0;
+        int spikes = 0;
+        int frametimeCount = 0;
 
         synchronized (buffer) {
             currentSize = size;
             currentDropped = droppedCount;
-            copy = Arrays.copyOf(buffer, capacity);
-        }
+            if (currentSize == 0) {
+                return TelemetrySnapshot.EMPTY;
+            }
 
-        if (currentSize == 0) {
-            return TelemetrySnapshot.EMPTY;
-        }
+            for (int i = 0; i < currentSize; i++) {
+                int index = (startIndex + i) % capacity;
+                TelemetrySample s = buffer[index];
+                if (s != null && s.hasFrametimeData()) {
+                    double ft = s.frametimeMs();
+                    frametimeScratch[frametimeCount++] = ft;
+                    sumFrametime += ft;
+                    frametimeSamples++;
 
-        // Calculate aggregates
-        double sumFrametime = 0;
-        int frametimeSamples = 0;
-        int spikes = 0;
-
-        // Collect valid samples
-        double[] frametimes = new double[currentSize];
-        int frametimeCount = 0;
-
-        for (int i = 0; i < currentSize; i++) {
-            TelemetrySample s = copy[i];
-            if (s != null && s.hasFrametimeData()) {
-                double ft = s.frametimeMs();
-                frametimes[frametimeCount++] = ft;
-                sumFrametime += ft;
-                frametimeSamples++;
-
-                if (ft > SPIKE_THRESHOLD_MS) {
-                    spikes++;
+                    if (ft > SPIKE_THRESHOLD_MS) {
+                        spikes++;
+                    }
                 }
             }
+
+            if (frametimeSamples == 0) {
+                return TelemetrySnapshot.EMPTY;
+            }
+
+            double avg = sumFrametime / frametimeSamples;
+            double p95 = calculateP95(frametimeScratch, frametimeCount);
+            return TelemetrySnapshot.of(avg, p95, spikes, currentSize, currentDropped);
         }
-
-        if (frametimeSamples == 0) {
-            return TelemetrySnapshot.EMPTY;
-        }
-
-        double avg = sumFrametime / frametimeSamples;
-
-        // Calculate P95
-        double p95 = calculateP95(frametimes, frametimeCount);
-
-        return TelemetrySnapshot.of(avg, p95, spikes, currentSize, currentDropped);
     }
 
     @Override
@@ -125,7 +117,7 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
     public void clear() {
         synchronized (buffer) {
             Arrays.fill(buffer, null);
-            writeIndex = 0;
+            startIndex = 0;
             size = 0;
             droppedCount = 0;
         }
@@ -140,12 +132,11 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
         }
 
         // Sort only the valid portion
-        double[] sorted = Arrays.copyOf(values, count);
-        Arrays.sort(sorted);
+        Arrays.sort(values, 0, count);
 
         int p95Index = (int) Math.ceil(count * 0.95) - 1;
         p95Index = Math.max(0, Math.min(p95Index, count - 1));
 
-        return sorted[p95Index];
+        return values[p95Index];
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce GC pressure and per-frame allocations on hot paths used by telemetry, tracing and action selection.
- Replace dynamic collections and temporary objects with pre-allocated ring buffers to avoid boxing/stream overhead in render/tick loops.
- Avoid Optional/boxing allocations in frequent GC checks to lower pause jitter.
- Improve deterministic behavior of candidate ordering by avoiding ephemeral `List` creation in the `ActionMatrix`.

### Description
- Replace `PerfTraceBuffer`'s `Deque` with a fixed-size ring array and index arithmetic to store events with `record()` and produce snapshots without per-event linked-list traversal.
- Convert `RingTelemetryBuffer` to use `startIndex`, reuse a preallocated `frametimeScratch` array for P95 calculation, and iterate the circular buffer under a single lock to avoid per-snapshot allocations.
- Change `GcPauseWatcher.update()` to return a `GcPauseEvent` (or `null`) instead of `Optional` and update `PerfManager` to check for `null`, removing Optional allocations on the frame path.
- Replace repeated `List.of(...)` enum-order constructions in `ActionMatrix.isQualityIncrease()` with static `String[]` tables and an `indexOf` helper to avoid allocating temporary lists.

### Testing
- No automated tests were executed for this change.
- Existing unit/integration tests were not run as part of this PR. 
- Runtime/bench validation for reduced GC pauses is pending and should be performed in real usage scenarios.
- Static inspection and repository compilation were used to verify edits (no test assertions were executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5b21b09c832da9ff3bcbdccd7238)