### PR TITLE
Add nozh-api contracts and compatibility agreements

### DIFF
--- a/docs/DOCUMENTATION_INVENTORY.md
+++ b/docs/DOCUMENTATION_INVENTORY.md
@@ -21,6 +21,7 @@
 - `docs/critical-notes-for-beta.md` — Notas críticas para la integración beta.
 - `docs/manual-validation.md` — Validación manual.
 - `docs/modpack-quick-test.md` — Quick test para modpacks.
+- `docs/nozh-api.md` — API pública para modders (contratos, stewardship y métricas).
 - `docs/technical-debt-audit.md` — Auditoría de deuda técnica.
 - `docs/telemetry-metrics.md` — Checklist de métricas de telemetría.
 - `docs/v0.2-alpha.md` — Documento de referencia de v0.2-alpha.

--- a/docs/nozh-api.md
+++ b/docs/nozh-api.md
@@ -1,0 +1,104 @@
+# NOZH API para modders
+
+Esta guía describe cómo integrarse con NOZH desde un mod externo usando los contratos
+de capabilities, declaraciones de stewardship y métricas internas.
+
+## Objetivos de la API
+
+- Declarar contratos de capabilities (tipo, rango, valores permitidos).
+- Informar acuerdos de stewardship (quién administra cada capability).
+- Exponer métricas internas para observabilidad.
+- Registrar acuerdos en `CompatibilityMatrix` para reportes y HUD.
+
+## Contratos de capabilities
+
+Los contratos viven en `dev.nozh.api.capability` y se registran mediante `NozhApi`.
+
+```java
+import dev.nozh.api.NozhApi;
+import dev.nozh.api.capability.CapabilityContract;
+import dev.nozh.api.capability.CapabilityContractDeclaration;
+import dev.nozh.core.bus.CapabilityId;
+import dev.nozh.core.bus.CapabilityValue;
+
+CapabilityContract contract = CapabilityContract.builder(
+        CapabilityId.RENDER_DISTANCE,
+        CapabilityContract.ValueType.INT)
+    .description("Distancia de renderizado controlada por el mod")
+    .range(4, 32)
+    .unit("chunks")
+    .defaultValue(new CapabilityValue.IntValue(12))
+    .build();
+
+CapabilityContractDeclaration declaration = CapabilityContractDeclaration
+    .builder("mi-mod", "Mi Mod")
+    .contract(contract)
+    .notes("Contrato validado en 1.20.4")
+    .build();
+
+NozhApi.registerCapabilityContracts(declaration);
+```
+
+## Stewardship (acuerdos de control)
+
+Usa `StewardshipDeclaration` para indicar si una capability es exclusiva o compartida.
+
+```java
+import dev.nozh.api.NozhApi;
+import dev.nozh.api.compat.StewardshipDeclaration;
+import dev.nozh.core.bus.CapabilityId;
+
+StewardshipDeclaration stewardship = StewardshipDeclaration
+    .builder("mi-mod", "Mi Mod")
+    .exclusive(CapabilityId.DYNAMIC_LIGHTING)
+    .shared(CapabilityId.CLOUDS)
+    .reason("El mod maneja estas opciones en runtime")
+    .build();
+
+NozhApi.registerStewardship(stewardship);
+```
+
+## Métricas internas
+
+Las métricas internas ayudan a reportar señales específicas del mod.
+
+```java
+import dev.nozh.api.NozhApi;
+import dev.nozh.api.metrics.ModMetricsDeclaration;
+import dev.nozh.core.bus.CapabilityId;
+
+ModMetricsDeclaration metrics = ModMetricsDeclaration
+    .builder("mi-mod", "Mi Mod")
+    .capabilities(CapabilityId.DYNAMIC_LIGHTING)
+    .metric("dynamic_lighting.apply.count",
+        ModMetricsDeclaration.MetricType.COUNTER,
+        "Cantidad de aplicaciones exitosas",
+        "calls")
+    .metric("dynamic_lighting.apply.latency",
+        ModMetricsDeclaration.MetricType.TIMER,
+        "Latencia promedio de aplicación",
+        "ms")
+    .notes("Métricas internas expuestas por el adaptador")
+    .build();
+
+NozhApi.registerModMetrics(metrics);
+```
+
+## Registrar acuerdos en CompatibilityMatrix
+
+`CompatibilityMatrix` ofrece acuerdos agregados para UI, reportes y diagnóstico:
+
+```java
+import dev.nozh.core.compatibility.CompatibilityMatrix;
+
+CompatibilityMatrix matrix = new CompatibilityMatrix();
+matrix.getAgreements().forEach(agreement -> {
+    // agreement.modId(), agreement.contracts(), agreement.metrics(), etc.
+});
+```
+
+## Recomendaciones
+
+- Registra contratos y métricas durante la inicialización del mod.
+- Evita declarar una capability como exclusiva si vas a permitir control compartido.
+- Mantén las descripciones claras para que el HUD muestre información útil.

--- a/src/main/java/dev/nozh/api/NozhApi.java
+++ b/src/main/java/dev/nozh/api/NozhApi.java
@@ -1,0 +1,30 @@
+package dev.nozh.api;
+
+import dev.nozh.api.capability.CapabilityContractDeclaration;
+import dev.nozh.api.compat.StewardshipDeclaration;
+import dev.nozh.api.metrics.ModMetricsDeclaration;
+import dev.nozh.core.compatibility.CapabilityContractRegistry;
+import dev.nozh.core.compatibility.ModMetricsRegistry;
+import dev.nozh.core.compatibility.StewardshipHandshakeRegistry;
+
+/**
+ * Entry point for third-party mods integrating with NOZH.
+ */
+public final class NozhApi {
+
+    public static void registerStewardship(StewardshipDeclaration declaration) {
+        StewardshipHandshakeRegistry.register(declaration);
+    }
+
+    public static void registerCapabilityContracts(CapabilityContractDeclaration declaration) {
+        CapabilityContractRegistry.register(declaration);
+    }
+
+    public static void registerModMetrics(ModMetricsDeclaration declaration) {
+        ModMetricsRegistry.register(declaration);
+    }
+
+    private NozhApi() {
+        // Utility class
+    }
+}

--- a/src/main/java/dev/nozh/api/capability/CapabilityContract.java
+++ b/src/main/java/dev/nozh/api/capability/CapabilityContract.java
@@ -1,0 +1,142 @@
+package dev.nozh.api.capability;
+
+import dev.nozh.core.bus.CapabilityId;
+import dev.nozh.core.bus.CapabilityValue;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Public contract describing how a capability behaves and what values it accepts.
+ */
+public final class CapabilityContract {
+
+    public enum ValueType {
+        INT,
+        FLOAT,
+        BOOL,
+        ENUM
+    }
+
+    private final CapabilityId capabilityId;
+    private final ValueType valueType;
+    private final String description;
+    private final CapabilityValue defaultValue;
+    private final Double minValue;
+    private final Double maxValue;
+    private final Set<String> allowedValues;
+    private final String unit;
+
+    private CapabilityContract(
+            CapabilityId capabilityId,
+            ValueType valueType,
+            String description,
+            CapabilityValue defaultValue,
+            Double minValue,
+            Double maxValue,
+            Set<String> allowedValues,
+            String unit) {
+        this.capabilityId = Objects.requireNonNull(capabilityId, "capabilityId");
+        this.valueType = Objects.requireNonNull(valueType, "valueType");
+        this.description = description == null ? "" : description;
+        this.defaultValue = defaultValue;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        this.allowedValues = allowedValues == null ? Set.of() : Set.copyOf(allowedValues);
+        this.unit = unit == null ? "" : unit;
+    }
+
+    public CapabilityId capabilityId() {
+        return capabilityId;
+    }
+
+    public ValueType valueType() {
+        return valueType;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public CapabilityValue defaultValue() {
+        return defaultValue;
+    }
+
+    public Double minValue() {
+        return minValue;
+    }
+
+    public Double maxValue() {
+        return maxValue;
+    }
+
+    public Set<String> allowedValues() {
+        return Collections.unmodifiableSet(allowedValues);
+    }
+
+    public String unit() {
+        return unit;
+    }
+
+    public static Builder builder(CapabilityId capabilityId, ValueType valueType) {
+        return new Builder(capabilityId, valueType);
+    }
+
+    public static final class Builder {
+        private final CapabilityId capabilityId;
+        private final ValueType valueType;
+        private String description;
+        private CapabilityValue defaultValue;
+        private Double minValue;
+        private Double maxValue;
+        private final Set<String> allowedValues = new LinkedHashSet<>();
+        private String unit;
+
+        private Builder(CapabilityId capabilityId, ValueType valueType) {
+            this.capabilityId = Objects.requireNonNull(capabilityId, "capabilityId");
+            this.valueType = Objects.requireNonNull(valueType, "valueType");
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder defaultValue(CapabilityValue defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public Builder range(double minValue, double maxValue) {
+            this.minValue = minValue;
+            this.maxValue = maxValue;
+            return this;
+        }
+
+        public Builder allowedValues(String... values) {
+            if (values != null) {
+                Collections.addAll(allowedValues, values);
+            }
+            return this;
+        }
+
+        public Builder unit(String unit) {
+            this.unit = unit;
+            return this;
+        }
+
+        public CapabilityContract build() {
+            return new CapabilityContract(
+                    capabilityId,
+                    valueType,
+                    description,
+                    defaultValue,
+                    minValue,
+                    maxValue,
+                    allowedValues,
+                    unit);
+        }
+    }
+}

--- a/src/main/java/dev/nozh/api/capability/CapabilityContractDeclaration.java
+++ b/src/main/java/dev/nozh/api/capability/CapabilityContractDeclaration.java
@@ -1,0 +1,83 @@
+package dev.nozh.api.capability;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Groups capability contracts under a mod declaration.
+ */
+public final class CapabilityContractDeclaration {
+
+    private final String modId;
+    private final String displayName;
+    private final List<CapabilityContract> contracts;
+    private final String notes;
+
+    private CapabilityContractDeclaration(
+            String modId,
+            String displayName,
+            List<CapabilityContract> contracts,
+            String notes) {
+        this.modId = modId;
+        this.displayName = displayName;
+        this.contracts = List.copyOf(contracts);
+        this.notes = notes == null ? "" : notes;
+    }
+
+    public String modId() {
+        return modId;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public List<CapabilityContract> contracts() {
+        return Collections.unmodifiableList(contracts);
+    }
+
+    public String notes() {
+        return notes;
+    }
+
+    public static Builder builder(String modId, String displayName) {
+        return new Builder(modId, displayName);
+    }
+
+    public static final class Builder {
+        private final String modId;
+        private final String displayName;
+        private final List<CapabilityContract> contracts = new ArrayList<>();
+        private String notes;
+
+        private Builder(String modId, String displayName) {
+            this.modId = Objects.requireNonNull(modId, "modId");
+            this.displayName = Objects.requireNonNull(displayName, "displayName");
+        }
+
+        public Builder contract(CapabilityContract contract) {
+            if (contract != null) {
+                contracts.add(contract);
+            }
+            return this;
+        }
+
+        public Builder contracts(List<CapabilityContract> contracts) {
+            if (contracts != null) {
+                this.contracts.addAll(contracts);
+            }
+            return this;
+        }
+
+        public Builder notes(String notes) {
+            this.notes = notes;
+            return this;
+        }
+
+        public CapabilityContractDeclaration build() {
+            return new CapabilityContractDeclaration(modId, displayName, contracts, notes);
+        }
+    }
+}

--- a/src/main/java/dev/nozh/api/metrics/ModMetricsDeclaration.java
+++ b/src/main/java/dev/nozh/api/metrics/ModMetricsDeclaration.java
@@ -1,0 +1,124 @@
+package dev.nozh.api.metrics;
+
+import dev.nozh.core.bus.CapabilityId;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Declares internal metrics exposed by a mod to NOZH.
+ */
+public final class ModMetricsDeclaration {
+
+    public enum MetricType {
+        COUNTER,
+        GAUGE,
+        HISTOGRAM,
+        TIMER,
+        EVENT
+    }
+
+    public record MetricDefinition(
+            String name,
+            MetricType type,
+            String description,
+            String unit) {
+        public MetricDefinition {
+            Objects.requireNonNull(name, "name");
+            Objects.requireNonNull(type, "type");
+        }
+    }
+
+    private final String modId;
+    private final String displayName;
+    private final EnumSet<CapabilityId> capabilities;
+    private final List<MetricDefinition> metrics;
+    private final String notes;
+
+    private ModMetricsDeclaration(
+            String modId,
+            String displayName,
+            EnumSet<CapabilityId> capabilities,
+            List<MetricDefinition> metrics,
+            String notes) {
+        this.modId = modId;
+        this.displayName = displayName;
+        this.capabilities = EnumSet.copyOf(capabilities);
+        this.metrics = List.copyOf(metrics);
+        this.notes = notes == null ? "" : notes;
+    }
+
+    public String modId() {
+        return modId;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public EnumSet<CapabilityId> capabilities() {
+        return EnumSet.copyOf(capabilities);
+    }
+
+    public List<MetricDefinition> metrics() {
+        return Collections.unmodifiableList(metrics);
+    }
+
+    public String notes() {
+        return notes;
+    }
+
+    public static Builder builder(String modId, String displayName) {
+        return new Builder(modId, displayName);
+    }
+
+    public static final class Builder {
+        private final String modId;
+        private final String displayName;
+        private final EnumSet<CapabilityId> capabilities = EnumSet.noneOf(CapabilityId.class);
+        private final List<MetricDefinition> metrics = new ArrayList<>();
+        private String notes;
+
+        private Builder(String modId, String displayName) {
+            this.modId = Objects.requireNonNull(modId, "modId");
+            this.displayName = Objects.requireNonNull(displayName, "displayName");
+        }
+
+        public Builder capability(CapabilityId capability) {
+            if (capability != null) {
+                capabilities.add(capability);
+            }
+            return this;
+        }
+
+        public Builder capabilities(CapabilityId... capabilities) {
+            if (capabilities != null) {
+                Collections.addAll(this.capabilities, capabilities);
+            }
+            return this;
+        }
+
+        public Builder metric(MetricDefinition metric) {
+            if (metric != null) {
+                metrics.add(metric);
+            }
+            return this;
+        }
+
+        public Builder metric(String name, MetricType type, String description, String unit) {
+            return metric(new MetricDefinition(name, type, description, unit));
+        }
+
+        public Builder notes(String notes) {
+            this.notes = notes;
+            return this;
+        }
+
+        public ModMetricsDeclaration build() {
+            return new ModMetricsDeclaration(modId, displayName, capabilities, metrics, notes);
+        }
+    }
+}

--- a/src/main/java/dev/nozh/core/compatibility/CapabilityContractRegistry.java
+++ b/src/main/java/dev/nozh/core/compatibility/CapabilityContractRegistry.java
@@ -1,0 +1,45 @@
+package dev.nozh.core.compatibility;
+
+import dev.nozh.api.capability.CapabilityContract;
+import dev.nozh.api.capability.CapabilityContractDeclaration;
+import dev.nozh.core.bus.CapabilityId;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class CapabilityContractRegistry {
+
+    private static final Map<String, CapabilityContractDeclaration> DECLARATIONS = new ConcurrentHashMap<>();
+
+    public static void register(CapabilityContractDeclaration declaration) {
+        if (declaration == null || declaration.modId() == null || declaration.modId().isBlank()) {
+            return;
+        }
+        DECLARATIONS.put(declaration.modId(), declaration);
+    }
+
+    public static List<CapabilityContractDeclaration> getDeclarations() {
+        return List.copyOf(DECLARATIONS.values());
+    }
+
+    public static List<CapabilityContract> getContracts(CapabilityId capabilityId) {
+        if (capabilityId == null) {
+            return List.of();
+        }
+        List<CapabilityContract> results = new ArrayList<>();
+        for (CapabilityContractDeclaration declaration : DECLARATIONS.values()) {
+            for (CapabilityContract contract : declaration.contracts()) {
+                if (capabilityId == contract.capabilityId()) {
+                    results.add(contract);
+                }
+            }
+        }
+        return results;
+    }
+
+    private CapabilityContractRegistry() {
+        // Static registry
+    }
+}

--- a/src/main/java/dev/nozh/core/compatibility/CompatibilityAgreement.java
+++ b/src/main/java/dev/nozh/core/compatibility/CompatibilityAgreement.java
@@ -1,0 +1,21 @@
+package dev.nozh.core.compatibility;
+
+import dev.nozh.api.capability.CapabilityContract;
+import dev.nozh.api.metrics.ModMetricsDeclaration;
+import dev.nozh.core.bus.CapabilityId;
+
+import java.util.EnumSet;
+import java.util.List;
+
+public record CompatibilityAgreement(
+        String modId,
+        String displayName,
+        EnumSet<CapabilityId> exclusiveCapabilities,
+        EnumSet<CapabilityId> sharedCapabilities,
+        String stewardshipReason,
+        List<CapabilityContract> contracts,
+        String contractNotes,
+        EnumSet<CapabilityId> metricCapabilities,
+        List<ModMetricsDeclaration.MetricDefinition> metrics,
+        String metricsNotes) {
+}

--- a/src/main/java/dev/nozh/core/compatibility/CompatibilityMatrix.java
+++ b/src/main/java/dev/nozh/core/compatibility/CompatibilityMatrix.java
@@ -1,12 +1,20 @@
 package dev.nozh.core.compatibility;
 
 import dev.nozh.core.bus.CapabilityId;
+import dev.nozh.api.capability.CapabilityContract;
+import dev.nozh.api.capability.CapabilityContractDeclaration;
+import dev.nozh.api.compat.StewardshipDeclaration;
+import dev.nozh.api.compat.StewardshipMode;
+import dev.nozh.api.metrics.ModMetricsDeclaration;
 import dev.nozh.core.capability.ProviderMetadata;
 import dev.nozh.fabric.compat.CompatRegistry;
-import dev.nozh.api.compat.StewardshipMode;
 import net.fabricmc.loader.api.FabricLoader;
 
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -124,5 +132,73 @@ public final class CompatibilityMatrix {
             }
         }
         return traces;
+    }
+
+    public List<CompatibilityAgreement> getAgreements() {
+        Map<String, AgreementBuilder> builders = new HashMap<>();
+
+        for (StewardshipDeclaration declaration : StewardshipHandshakeRegistry.getDeclarations()) {
+            AgreementBuilder builder = builders.computeIfAbsent(
+                    declaration.modId(),
+                    key -> new AgreementBuilder(declaration.modId(), declaration.displayName()));
+            builder.stewardshipReason = declaration.reason();
+            builder.sharedCapabilities.addAll(declaration.sharedCapabilities());
+            builder.exclusiveCapabilities.addAll(declaration.exclusiveCapabilities());
+        }
+
+        for (CapabilityContractDeclaration declaration : CapabilityContractRegistry.getDeclarations()) {
+            AgreementBuilder builder = builders.computeIfAbsent(
+                    declaration.modId(),
+                    key -> new AgreementBuilder(declaration.modId(), declaration.displayName()));
+            builder.contractNotes = declaration.notes();
+            builder.contracts.addAll(declaration.contracts());
+        }
+
+        for (ModMetricsDeclaration declaration : ModMetricsRegistry.getDeclarations()) {
+            AgreementBuilder builder = builders.computeIfAbsent(
+                    declaration.modId(),
+                    key -> new AgreementBuilder(declaration.modId(), declaration.displayName()));
+            builder.metricsNotes = declaration.notes();
+            builder.metrics.addAll(declaration.metrics());
+            builder.metricCapabilities.addAll(declaration.capabilities());
+        }
+
+        List<CompatibilityAgreement> agreements = new ArrayList<>();
+        for (AgreementBuilder builder : builders.values()) {
+            agreements.add(builder.build());
+        }
+        return agreements;
+    }
+
+    private static final class AgreementBuilder {
+        private final String modId;
+        private final String displayName;
+        private final EnumSet<CapabilityId> exclusiveCapabilities = EnumSet.noneOf(CapabilityId.class);
+        private final EnumSet<CapabilityId> sharedCapabilities = EnumSet.noneOf(CapabilityId.class);
+        private String stewardshipReason = "";
+        private final List<CapabilityContract> contracts = new ArrayList<>();
+        private String contractNotes = "";
+        private final EnumSet<CapabilityId> metricCapabilities = EnumSet.noneOf(CapabilityId.class);
+        private final List<ModMetricsDeclaration.MetricDefinition> metrics = new ArrayList<>();
+        private String metricsNotes = "";
+
+        private AgreementBuilder(String modId, String displayName) {
+            this.modId = modId;
+            this.displayName = displayName;
+        }
+
+        private CompatibilityAgreement build() {
+            return new CompatibilityAgreement(
+                    modId,
+                    displayName,
+                    EnumSet.copyOf(exclusiveCapabilities),
+                    EnumSet.copyOf(sharedCapabilities),
+                    stewardshipReason,
+                    List.copyOf(contracts),
+                    contractNotes,
+                    EnumSet.copyOf(metricCapabilities),
+                    List.copyOf(metrics),
+                    metricsNotes);
+        }
     }
 }

--- a/src/main/java/dev/nozh/core/compatibility/ModMetricsRegistry.java
+++ b/src/main/java/dev/nozh/core/compatibility/ModMetricsRegistry.java
@@ -1,0 +1,27 @@
+package dev.nozh.core.compatibility;
+
+import dev.nozh.api.metrics.ModMetricsDeclaration;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class ModMetricsRegistry {
+
+    private static final Map<String, ModMetricsDeclaration> DECLARATIONS = new ConcurrentHashMap<>();
+
+    public static void register(ModMetricsDeclaration declaration) {
+        if (declaration == null || declaration.modId() == null || declaration.modId().isBlank()) {
+            return;
+        }
+        DECLARATIONS.put(declaration.modId(), declaration);
+    }
+
+    public static List<ModMetricsDeclaration> getDeclarations() {
+        return List.copyOf(DECLARATIONS.values());
+    }
+
+    private ModMetricsRegistry() {
+        // Static registry
+    }
+}

--- a/src/main/java/dev/nozh/core/compatibility/StewardshipHandshakeRegistry.java
+++ b/src/main/java/dev/nozh/core/compatibility/StewardshipHandshakeRegistry.java
@@ -63,6 +63,10 @@ public final class StewardshipHandshakeRegistry {
         return traces;
     }
 
+    public static List<StewardshipDeclaration> getDeclarations() {
+        return List.copyOf(DECLARATIONS.values());
+    }
+
     private static boolean isModLoaded(String modId) {
         try {
             return FabricLoader.getInstance().isModLoaded(modId);


### PR DESCRIPTION
### Motivation

- Formalize a public modder API so external mods can declare capability contracts and be discovered by NOZH.
- Allow mods to declare stewardship modes and surface those agreements to conflict detection and UI.
- Enable mods to expose internal metrics so NOZH can include those signals in observability and reports.
- Aggregate these declarations into the compatibility subsystem so reports and the HUD can show agreed contracts and metrics.

### Description

- Add a modder entrypoint `NozhApi` and API types `CapabilityContract`, `CapabilityContractDeclaration`, and `ModMetricsDeclaration` in `dev.nozh.api` to declare contracts and metrics.
- Add registries `CapabilityContractRegistry` and `ModMetricsRegistry`, a `CompatibilityAgreement` record, and extend `CompatibilityMatrix` with `getAgreements()` to aggregate stewardship, contracts and metrics.
- Expose stewardship declarations via `StewardshipHandshakeRegistry.getDeclarations()` and wire `NozhApi.register*` to the new registries so mods can register at init time.
- Add documentation `docs/nozh-api.md` and update `docs/DOCUMENTATION_INVENTORY.md` to describe usage and examples for modders.

### Testing

- No automated tests were executed for these changes.
- Recommend running the existing unit and integration test suites and a local build to validate API compatibility and compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5b2367f0832d9e3f9030800580b6)