### PR TITLE
Adaptive telemetry sampling, compact exports, and overhead tracking

### DIFF
--- a/src/main/java/dev/nozh/client/NozhCommands.java
+++ b/src/main/java/dev/nozh/client/NozhCommands.java
@@ -83,6 +83,16 @@ public final class NozhCommands {
                                                     .executes(context -> {
                                                         runTelemetryExport(context.getSource(), TelemetryExportFormat.JSON);
                                                         return 1;
+                                                    }))
+                                            .then(ClientCommandManager.literal("compact-csv")
+                                                    .executes(context -> {
+                                                        runTelemetryExport(context.getSource(), TelemetryExportFormat.COMPACT_CSV);
+                                                        return 1;
+                                                    }))
+                                            .then(ClientCommandManager.literal("compact-json")
+                                                    .executes(context -> {
+                                                        runTelemetryExport(context.getSource(), TelemetryExportFormat.COMPACT_JSON);
+                                                        return 1;
                                                     }))))
                             .then(ClientCommandManager.literal("enable")
                                     .executes(context -> {

--- a/src/main/java/dev/nozh/core/benchmark/BenchmarkScenarioRecorder.java
+++ b/src/main/java/dev/nozh/core/benchmark/BenchmarkScenarioRecorder.java
@@ -117,7 +117,7 @@ public final class BenchmarkScenarioRecorder {
             Path decisionLatencyJson = null;
             for (TelemetryExportFormat format : formats) {
                 Path export = perfManager != null ? perfManager.exportTelemetry(sessionDir, format) : null;
-                if (format == TelemetryExportFormat.CSV) {
+                if (format.isCsv()) {
                     csv = export;
                 } else {
                     json = export;

--- a/src/main/java/dev/nozh/core/profiler/BenchmarkSession.java
+++ b/src/main/java/dev/nozh/core/profiler/BenchmarkSession.java
@@ -82,8 +82,12 @@ public final class BenchmarkSession {
                 .withZone(ZoneOffset.UTC)
                 .format(Instant.ofEpochMilli(snapshot.timestampMillis()));
         String sanitizedLabel = label != null && !label.isBlank() ? label.trim().replaceAll("\\s+", "_") : "session";
-        String extension = format == TelemetryExportFormat.CSV ? "csv" : "json";
-        Path outputFile = outputDir.resolve("benchmark_" + sanitizedLabel + "_" + timestamp + "." + extension);
+        String suffix = format.fileSuffix();
+        String extension = format.fileExtension();
+        String name = suffix.isEmpty()
+                ? "benchmark_" + sanitizedLabel + "_" + timestamp
+                : "benchmark_" + sanitizedLabel + "_" + timestamp + "_" + suffix;
+        Path outputFile = outputDir.resolve(name + "." + extension);
         TelemetryExportWriter.write(snapshot, samples, outputFile, format);
         return new BenchmarkSessionReport(snapshot, samples, outputFile, format, windowSeconds, capacity, startedAtMillis);
     }

--- a/src/main/java/dev/nozh/core/profiler/PerfManager.java
+++ b/src/main/java/dev/nozh/core/profiler/PerfManager.java
@@ -131,8 +131,10 @@ public class PerfManager implements CriticalEventSink {
         String timestamp = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
                 .withZone(ZoneOffset.UTC)
                 .format(Instant.ofEpochMilli(snapshot.timestampMillis()));
-        String extension = format == TelemetryExportFormat.CSV ? "csv" : "json";
-        Path outputFile = outputDir.resolve("telemetry_" + timestamp + "." + extension);
+        String suffix = format.fileSuffix();
+        String extension = format.fileExtension();
+        String name = suffix.isEmpty() ? "telemetry_" + timestamp : "telemetry_" + timestamp + "_" + suffix;
+        Path outputFile = outputDir.resolve(name + "." + extension);
         return TelemetryExportWriter.write(report, outputFile, format);
     }
 

--- a/src/main/java/dev/nozh/core/telemetry/RingTelemetryBuffer.java
+++ b/src/main/java/dev/nozh/core/telemetry/RingTelemetryBuffer.java
@@ -25,6 +25,16 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
     private volatile int droppedCount = 0;
 
     private static final double SPIKE_THRESHOLD_MS = 50.0; // Configurable
+    private static final int SPIKE_BURST_SAMPLES = 120;
+    private static final int STABLE_SAMPLE_WINDOW = 180;
+    private static final int BASE_SAMPLE_STRIDE = 4;
+
+    private int sampleStride = 1;
+    private int sampleCounter = 0;
+    private int stableSampleCount = 0;
+    private int spikeBurstRemaining = 0;
+    private int overheadSampleCounter = 0;
+    private volatile long averageAddNanos = 0;
 
     public RingTelemetryBuffer(int capacity) {
         if (capacity <= 0) {
@@ -43,8 +53,38 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
 
     @Override
     public void add(TelemetrySample sample) {
+        long startNanos = 0;
+        boolean trackOverhead = (overheadSampleCounter++ & 0xF) == 0;
+        if (trackOverhead) {
+            startNanos = System.nanoTime();
+        }
+
         if (sample == null) {
+            recordOverheadIfNeeded(trackOverhead, startNanos);
             return; // Fail silently per Contract 4
+        }
+
+        boolean spike = sample.hasFrametimeData() && sample.frametimeMs() > SPIKE_THRESHOLD_MS;
+        if (spike) {
+            spikeBurstRemaining = SPIKE_BURST_SAMPLES;
+        }
+
+        if (spikeBurstRemaining > 0) {
+            if (!spike) {
+                spikeBurstRemaining--;
+            }
+            sampleStride = 1;
+            stableSampleCount = 0;
+        } else {
+            stableSampleCount++;
+            sampleStride = stableSampleCount >= STABLE_SAMPLE_WINDOW ? BASE_SAMPLE_STRIDE : 1;
+        }
+
+        if (!spike && spikeBurstRemaining == 0 && sampleStride > 1) {
+            if ((sampleCounter++ % sampleStride) != 0) {
+                recordOverheadIfNeeded(trackOverhead, startNanos);
+                return;
+            }
         }
 
         try {
@@ -62,6 +102,8 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
         } catch (Exception e) {
             // NEVER throw - Contract 4.7
             droppedCount++;
+        } finally {
+            recordOverheadIfNeeded(trackOverhead, startNanos);
         }
     }
 
@@ -132,6 +174,20 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
     }
 
     /**
+     * Average sampled add() overhead in microseconds.
+     */
+    public double getAverageAddOverheadMicros() {
+        return averageAddNanos / 1000.0;
+    }
+
+    /**
+     * Check if average sampled add() overhead is within budget in milliseconds.
+     */
+    public boolean isOverheadWithinBudget(double maxMs) {
+        return averageAddNanos <= (long) (maxMs * 1_000_000.0);
+    }
+
+    /**
      * Calculate P95 from sorted array segment.
      */
     private double calculateP95(double[] values, int count) {
@@ -147,5 +203,20 @@ public final class RingTelemetryBuffer implements TelemetryBuffer {
         p95Index = Math.max(0, Math.min(p95Index, count - 1));
 
         return sorted[p95Index];
+    }
+
+    private void recordOverheadIfNeeded(boolean trackOverhead, long startNanos) {
+        if (!trackOverhead) {
+            return;
+        }
+        long duration = System.nanoTime() - startNanos;
+        if (duration <= 0) {
+            return;
+        }
+        if (averageAddNanos == 0) {
+            averageAddNanos = duration;
+        } else {
+            averageAddNanos = (averageAddNanos * 15 + duration) / 16;
+        }
     }
 }

--- a/src/main/java/dev/nozh/core/telemetry/TelemetryExportFormat.java
+++ b/src/main/java/dev/nozh/core/telemetry/TelemetryExportFormat.java
@@ -1,6 +1,32 @@
 package dev.nozh.core.telemetry;
 
 public enum TelemetryExportFormat {
-    CSV,
-    JSON
+    CSV("csv", ""),
+    JSON("json", ""),
+    COMPACT_CSV("csv", "compact"),
+    COMPACT_JSON("json", "compact");
+
+    private final String fileExtension;
+    private final String fileSuffix;
+
+    TelemetryExportFormat(String fileExtension, String fileSuffix) {
+        this.fileExtension = fileExtension;
+        this.fileSuffix = fileSuffix;
+    }
+
+    public String fileExtension() {
+        return fileExtension;
+    }
+
+    public String fileSuffix() {
+        return fileSuffix;
+    }
+
+    public boolean isCsv() {
+        return this == CSV || this == COMPACT_CSV;
+    }
+
+    public boolean isCompact() {
+        return this == COMPACT_CSV || this == COMPACT_JSON;
+    }
 }

--- a/src/main/java/dev/nozh/core/telemetry/TelemetryExportWriter.java
+++ b/src/main/java/dev/nozh/core/telemetry/TelemetryExportWriter.java
@@ -29,6 +29,10 @@ public final class TelemetryExportWriter {
     public static Path write(PerfReport report, Path outputFile, TelemetryExportFormat format) throws Exception {
         if (format == TelemetryExportFormat.CSV) {
             Files.writeString(outputFile, toCsv(report), StandardCharsets.UTF_8);
+        } else if (format == TelemetryExportFormat.COMPACT_CSV) {
+            Files.writeString(outputFile, toCompactCsv(report), StandardCharsets.UTF_8);
+        } else if (format == TelemetryExportFormat.COMPACT_JSON) {
+            Files.writeString(outputFile, toCompactJson(report), StandardCharsets.UTF_8);
         } else {
             Files.writeString(outputFile, toJson(report), StandardCharsets.UTF_8);
         }
@@ -94,6 +98,87 @@ public final class TelemetryExportWriter {
         appendTraceJson(sb, report);
         sb.append("}\n");
         return sb.toString();
+    }
+
+    private static String toCompactCsv(PerfReport report) {
+        PerfSnapshot snapshot = report.frameSnapshot();
+        PerfSnapshot tickSnapshot = report.tickSnapshot();
+        long[] samplesNanos = report.frameSamplesNanos();
+        DeltaSamples delta = DeltaSamples.from(samplesNanos);
+        StringBuilder sb = new StringBuilder();
+        sb.append("samples_base_us,").append(delta.baseMicros()).append('\n');
+        sb.append("index,delta_us\n");
+        for (int i = 0; i < delta.deltaMicros().length; i++) {
+            sb.append(i + 1).append(',').append(delta.deltaMicros()[i]).append('\n');
+        }
+        sb.append("\n");
+        sb.append("avg_ms,").append(formatMetricForCsv(snapshot.avgFrametimeMs())).append('\n');
+        sb.append("p95_ms,").append(formatMetricForCsv(snapshot.p95FrametimeMs())).append('\n');
+        sb.append("spikes,").append(snapshot.spikeCount()).append('\n');
+        sb.append("samples,").append(snapshot.sampleCount()).append('\n');
+        sb.append("window_seconds,").append(snapshot.windowSeconds()).append('\n');
+        sb.append("timestamp_ms,").append(snapshot.timestampMillis()).append('\n');
+        sb.append("\n");
+        sb.append("tick_avg_ms,").append(formatMetricForCsv(tickSnapshot.avgFrametimeMs())).append('\n');
+        sb.append("tick_p95_ms,").append(formatMetricForCsv(tickSnapshot.p95FrametimeMs())).append('\n');
+        sb.append("tick_samples,").append(tickSnapshot.sampleCount()).append('\n');
+        sb.append("tick_window_seconds,").append(tickSnapshot.windowSeconds()).append('\n');
+        appendDiagnosticsCsv(sb, report);
+        appendTraceCsv(sb, report);
+        return sb.toString();
+    }
+
+    private static String toCompactJson(PerfReport report) {
+        PerfSnapshot snapshot = report.frameSnapshot();
+        PerfSnapshot tickSnapshot = report.tickSnapshot();
+        long[] samplesNanos = report.frameSamplesNanos();
+        DeltaSamples delta = DeltaSamples.from(samplesNanos);
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"frame\": {\n");
+        sb.append("    \"avgFrametimeMs\": ").append(formatMetricForJson(snapshot.avgFrametimeMs())).append(",\n");
+        sb.append("    \"p95FrametimeMs\": ").append(formatMetricForJson(snapshot.p95FrametimeMs())).append(",\n");
+        sb.append("    \"spikeCount\": ").append(snapshot.spikeCount()).append(",\n");
+        sb.append("    \"sampleCount\": ").append(snapshot.sampleCount()).append(",\n");
+        sb.append("    \"windowSeconds\": ").append(snapshot.windowSeconds()).append(",\n");
+        sb.append("    \"timestampMillis\": ").append(snapshot.timestampMillis()).append("\n");
+        sb.append("  },\n");
+        sb.append("  \"tick\": {\n");
+        sb.append("    \"avgTickMs\": ").append(formatMetricForJson(tickSnapshot.avgFrametimeMs())).append(",\n");
+        sb.append("    \"p95TickMs\": ").append(formatMetricForJson(tickSnapshot.p95FrametimeMs())).append(",\n");
+        sb.append("    \"sampleCount\": ").append(tickSnapshot.sampleCount()).append(",\n");
+        sb.append("    \"windowSeconds\": ").append(tickSnapshot.windowSeconds()).append("\n");
+        sb.append("  },\n");
+        sb.append("  \"samplesBaseUs\": ").append(delta.baseMicros()).append(",\n");
+        sb.append("  \"samplesDeltaUs\": [");
+        for (int i = 0; i < delta.deltaMicros().length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(delta.deltaMicros()[i]);
+        }
+        sb.append("],\n");
+        appendDiagnosticsJson(sb, report);
+        appendTraceJson(sb, report);
+        sb.append("}\n");
+        return sb.toString();
+    }
+
+    private record DeltaSamples(long baseMicros, long[] deltaMicros) {
+        private static DeltaSamples from(long[] samplesNanos) {
+            if (samplesNanos == null || samplesNanos.length == 0) {
+                return new DeltaSamples(0, new long[0]);
+            }
+            long baseMicros = nanosToMicros(samplesNanos[0]);
+            long[] deltaMicros = new long[Math.max(0, samplesNanos.length - 1)];
+            long previous = samplesNanos[0];
+            for (int i = 1; i < samplesNanos.length; i++) {
+                long current = samplesNanos[i];
+                deltaMicros[i - 1] = nanosToMicros(current - previous);
+                previous = current;
+            }
+            return new DeltaSamples(baseMicros, deltaMicros);
+        }
     }
 
     private static void appendDiagnosticsCsv(StringBuilder sb, PerfReport report) {
@@ -246,5 +331,9 @@ public final class TelemetryExportWriter {
             return "\"--\"";
         }
         return String.format("%.3f", value);
+    }
+
+    private static long nanosToMicros(long nanos) {
+        return Math.round(nanos / 1000.0);
     }
 }

--- a/src/test/java/dev/nozh/core/telemetry/TelemetryOverheadTest.java
+++ b/src/test/java/dev/nozh/core/telemetry/TelemetryOverheadTest.java
@@ -1,0 +1,35 @@
+package dev.nozh.core.telemetry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates telemetry buffer overhead stays within budget.
+ */
+class TelemetryOverheadTest {
+
+    @Test
+    void addOverheadWithinBudget() {
+        RingTelemetryBuffer buffer = new RingTelemetryBuffer(256);
+        TelemetrySample sample = new TelemetrySample(
+                System.currentTimeMillis(),
+                16.0,
+                5.0,
+                60,
+                100,
+                50,
+                1000,
+                0);
+
+        int iterations = 10_000;
+        long start = System.nanoTime();
+        for (int i = 0; i < iterations; i++) {
+            buffer.add(sample);
+        }
+        long elapsed = System.nanoTime() - start;
+        double avgMs = (elapsed / 1_000_000.0) / iterations;
+
+        assertTrue(avgMs < 0.1, "Average add() overhead should be < 0.1ms");
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce telemetry data volume during stable periods while retaining dense data when spikes occur by adding adaptive sampling behavior to the buffer.
- Lower export size and make sample data more compact by adding delta-encoded / chunked export formats.
- Expose compact export options to users and make file naming explicit for compact formats.
- Ensure telemetry sampling itself adds minimal overhead and provide helpers to measure and enforce the budget.

### Description

- Implemented adaptive sampling and overhead measurement inside `RingTelemetryBuffer` including spike burst retention, stable-window stride, sampled overhead tracking, and public helpers `getAverageAddOverheadMicros()` and `isOverheadWithinBudget()`.
- Added compact export formats `COMPACT_CSV` and `COMPACT_JSON` to `TelemetryExportFormat` and implemented delta-encoded exporters `toCompactCsv()` and `toCompactJson()` (with `DeltaSamples`) in `TelemetryExportWriter`.
- Updated `PerfManager`, `BenchmarkSession`, and `BenchmarkScenarioRecorder` to use format file suffix/extension naming, and added CLI commands `compact-csv` / `compact-json` in `NozhCommands` to expose the new formats.
- Added unit test `TelemetryOverheadTest` to validate average `add()` overhead target (< 0.1ms) for the buffer.

### Testing

- Added the automated test `dev.nozh.core.telemetry.TelemetryOverheadTest` (new unit test file).
- Attempted to run `./gradlew test --tests dev.nozh.core.telemetry.TelemetryOverheadTest`, but the test run failed due to test dependency resolution errors (Gradle failed to fetch JUnit artifacts with HTTP 403), so the automated test could not be executed in this environment.
- Project compilation of production classes completed (default `compileJava` phase succeeded), while `compileTestJava` failed due to remote dependency fetch errors during the test run.
- No other automated test failures produced by these changes in the current execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5b244fb4832db10a9b1999c3d788)