### PR TITLE
Refine config defaults and validation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@
 - Some capabilities are **DEGRADED or no-op** in vanilla; NOZH will back off in those cases.
 - External mod updates can break reflection-based adapters (Sodium/Iris APIs are not stable).
 
+## Configuration (recommended defaults)
+
+These defaults are tuned for **real hardware baselines** and common 60–144 Hz panels:
+
+- `targetFps = 60` (set to 120/144/240 if your monitor and GPU can sustain it).
+- `observationWindowSeconds = 5` (enough samples to smooth spikes without lagging reactions).
+- `cooldownActionMillis = 120000` (per-action cooldown to avoid churn).
+- `cooldownGlobalMinIntervalMillis = 60000` (global guardrail between any actions).
+
 ## Rough progress estimate (subjective)
 
 - **Core loop + telemetry + HUD:** ~70–80% complete.
@@ -128,6 +137,15 @@ Overall: **~45–55% of the “full vision”** described in `future.txt` + extr
 - La detección de escenarios es heurística y puede fallar (p. ej. construcción con inventario puede parecer AFK).
 - Algunas capacidades están **DEGRADED o no-op** en vanilla; NOZH retrocede en esos casos.
 - Actualizaciones de mods externos pueden romper adapters basados en reflection.
+
+## Configuración (defaults recomendados)
+
+Estos defaults están afinados para **hardware real** y paneles comunes de 60–144 Hz:
+
+- `targetFps = 60` (sube a 120/144/240 si tu monitor y GPU lo sostienen).
+- `observationWindowSeconds = 5` (suficientes muestras sin retrasar la reacción).
+- `cooldownActionMillis = 120000` (cooldown por acción para evitar oscilaciones).
+- `cooldownGlobalMinIntervalMillis = 60000` (mínimo global entre acciones).
 
 ## Estimación de progreso (subjetiva)
 

--- a/src/main/java/dev/nozh/core/config/ConfigManager.java
+++ b/src/main/java/dev/nozh/core/config/ConfigManager.java
@@ -61,6 +61,13 @@ public final class ConfigManager {
                         config = migrated;
 
                         boolean corrected = config.validate();
+                        if (corrected) {
+                            java.util.List<String> criticalCorrections = config.consumeCriticalCorrections();
+                            if (!criticalCorrections.isEmpty()) {
+                                NozhConstants.LOGGER.warn("CRITICAL config corrections applied: {}",
+                                        String.join("; ", criticalCorrections));
+                            }
+                        }
                         boolean hardwareUpdated = ensureHardwareProfile(config);
                         if (corrected || migrated != loaded) {
                             NozhConstants.LOGGER.warn("Config had invalid values or was migrated, re-saving");

--- a/src/main/java/dev/nozh/core/config/NozhConfig.java
+++ b/src/main/java/dev/nozh/core/config/NozhConfig.java
@@ -11,61 +11,61 @@ import dev.nozh.NozhConstants;
 public class NozhConfig {
 
     // Core
-    public boolean enabled = true;
-    public boolean debugLogs = false;
-    public String language = "auto"; // "auto", "en_us", "es_cl"
-    public boolean showHud = true;
-    public boolean showHudSuggestions = true;
-    public String hudMode = "ANALYST"; // COMPACT, ANALYST, EXPERT
-    public String hudAnchor = "TOP_LEFT"; // TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT
-    public int hudOffsetX = 0;
-    public int hudOffsetY = 0;
-    public double hudScale = 1.0;
-    public int tutorialStep = 0; // 0=welcome, 1=apply, 2=export, 3=complete
+    public boolean enabled = true; // Master switch: enables/disables the entire governor runtime.
+    public boolean debugLogs = false; // Verbose logs for diagnosis; increases log volume.
+    public String language = "auto"; // UI language override: "auto", "en_us", "es_cl".
+    public boolean showHud = true; // Controls HUD visibility in-game.
+    public boolean showHudSuggestions = true; // Shows action suggestions in HUD for guidance.
+    public String hudMode = "ANALYST"; // HUD density preset: COMPACT, ANALYST, EXPERT.
+    public String hudAnchor = "TOP_LEFT"; // HUD anchor position on screen edges.
+    public int hudOffsetX = 0; // Horizontal offset (pixels) from anchor.
+    public int hudOffsetY = 0; // Vertical offset (pixels) from anchor.
+    public double hudScale = 1.0; // HUD scale factor for readability (1.0 = 100%).
+    public int tutorialStep = 0; // Onboarding step (0=welcome, 1=apply, 2=export, 3=complete).
 
     // Version tracking for migrations
-    public int configVersion = 0; // 0=v0.1.0, 1=legacy, 2=v0.2.0-alpha
+    public int configVersion = 0; // Migration tracking (0=v0.1.0, 1=legacy, 2=v0.2.0-alpha).
 
     // Feature Toggles
-    public boolean allowAutoTuning = false;
-    public boolean allowGameplayImpactActions = false; // Phase 8: Level 2/3 actions
-    public boolean safeModeForce = false;
-    public boolean rollbackEnabled = true;
-    public boolean hybridModelEnabled = true;
+    public boolean allowAutoTuning = false; // Allows automatic actions without manual confirmation.
+    public boolean allowGameplayImpactActions = false; // Enables higher-impact actions (Phase 8 L2/L3).
+    public boolean safeModeForce = false; // Forces safe mode when compatibility risk is detected.
+    public boolean rollbackEnabled = true; // Enables rollback when telemetry worsens after changes.
+    public boolean hybridModelEnabled = true; // Enables hybrid decision logic for stability.
 
     // Tuning Parameters (Rollback)
-    public int rollbackWindowMillis = 45000;
-    public double improvementEpsilonAvgMs = 0.5;
-    public double improvementEpsilonP95Ms = 1.0;
-    public int rollbackEvaluationTicks = 100;
-    public int rollbackCooldownMillis = 60000;
-    public int observationWindowSeconds = 5;
-    public double hybridModelBlockConfidence = 0.65;
-    public int governorDecisionBudgetMs = 8;
+    public int rollbackWindowMillis = 45000; // Lookback window for rollback evaluation (ms).
+    public double improvementEpsilonAvgMs = 0.5; // Avg frametime delta required to call it "better".
+    public double improvementEpsilonP95Ms = 1.0; // p95 frametime delta required to call it "better".
+    public int rollbackEvaluationTicks = 100; // Sample count before concluding rollback is needed.
+    public int rollbackCooldownMillis = 60000; // Cooldown between rollbacks to avoid oscillation.
+    public int observationWindowSeconds = 5; // Telemetry window; 5s ~ 300 samples @ 60 FPS.
+    public double hybridModelBlockConfidence = 0.65; // Confidence to block risky actions in hybrid mode.
+    public int governorDecisionBudgetMs = 8; // Max CPU budget per decision tick (ms).
 
     // Performance Targets
-    public int targetFps = 60;
-    public String optimizationProfile = "BALANCED";
-    public double reverseEpsilonMs = 1.5;
+    public int targetFps = 60; // Target FPS aligned with typical 60Hz panels (adjust to 120/144/240).
+    public String optimizationProfile = "BALANCED"; // Overall aggressiveness of tuning.
+    public double reverseEpsilonMs = 1.5; // Delta before reversing changes (ms).
 
     // Benchmark & Calibration
-    public boolean benchmarkModeEnabled = false;
-    public int benchmarkMicroIntervalMillis = 5000;
-    public String hardwareProfile = "";
+    public boolean benchmarkModeEnabled = false; // Enables synthetic benchmarking for calibration.
+    public int benchmarkMicroIntervalMillis = 5000; // Granularity of benchmark telemetry snapshots.
+    public String hardwareProfile = ""; // Persisted HW profile hash for telemetry baselines.
 
     // Adaptive Visual Quality
-    public boolean adaptiveVisualQualityEnabled = true;
-    public double adaptiveVisualQualitySensitivityMs = 1.5;
-    public int adaptiveVisualQualityMinStep = 0;
-    public int adaptiveVisualQualityMaxStep = 17;
+    public boolean adaptiveVisualQualityEnabled = true; // Allows adaptive graphics tradeoffs.
+    public double adaptiveVisualQualitySensitivityMs = 1.5; // Sensitivity to frametime spikes (ms).
+    public int adaptiveVisualQualityMinStep = 0; // Lower bound on adaptive quality steps.
+    public int adaptiveVisualQualityMaxStep = 17; // Upper bound on adaptive quality steps.
 
     // Limits & Cooldowns
-    public int historyMaxEntries = 50;
-    public int historyCommandLimit = 10;
-    public int cooldownActionMillis = 120000; // 2 min default
-    public int cooldownGlobalMinIntervalMillis = 60000; // 1 min default
-    public int maxChangesPerSession = 2; // Strict default
-    public int evalPeriodTicks = 100;
+    public int historyMaxEntries = 50; // Max telemetry/action history entries stored in-memory.
+    public int historyCommandLimit = 10; // Max entries shown per history command request.
+    public int cooldownActionMillis = 120000; // Per-action cooldown to avoid repeating tweaks too fast.
+    public int cooldownGlobalMinIntervalMillis = 60000; // Global minimum interval between any actions.
+    public int maxChangesPerSession = 2; // Max applied changes per session for stability.
+    public int evalPeriodTicks = 100; // Ticks between evaluation cycles.
 
     // Migration / Legacy compatibility (hidden/mapped)
     // We remove old fields. JSON parsing will ignore unknown keys in the file,
@@ -75,6 +75,7 @@ public class NozhConfig {
 
     // Transient state
     private transient boolean wasCorrected = false;
+    private transient java.util.List<String> criticalCorrections = new java.util.ArrayList<>();
 
     public boolean wasCorrected() {
         return wasCorrected;
@@ -91,10 +92,16 @@ public class NozhConfig {
     public boolean validate() {
         boolean corrected = false;
 
+        if (language == null || language.isBlank()) {
+            language = "auto";
+            corrected = true;
+        }
+
         // targetFps: 30-240
         if (targetFps < 30 || targetFps > 240) {
             targetFps = clamp(targetFps, 30, 240);
             corrected = true;
+            addCriticalCorrection("targetFps clamped to " + targetFps + " (30-240)");
         }
 
         if (optimizationProfile == null
@@ -104,7 +111,10 @@ public class NozhConfig {
             corrected = true;
         }
 
-        if (reverseEpsilonMs < 0.0 || reverseEpsilonMs > 8.0) {
+        if (!isFinite(reverseEpsilonMs)) {
+            reverseEpsilonMs = 1.5;
+            corrected = true;
+        } else if (reverseEpsilonMs < 0.0 || reverseEpsilonMs > 8.0) {
             reverseEpsilonMs = clamp(reverseEpsilonMs, 0.0, 8.0);
             corrected = true;
         }
@@ -114,7 +124,10 @@ public class NozhConfig {
             corrected = true;
         }
 
-        if (adaptiveVisualQualitySensitivityMs < 0.25 || adaptiveVisualQualitySensitivityMs > 8.0) {
+        if (!isFinite(adaptiveVisualQualitySensitivityMs)) {
+            adaptiveVisualQualitySensitivityMs = 1.5;
+            corrected = true;
+        } else if (adaptiveVisualQualitySensitivityMs < 0.25 || adaptiveVisualQualitySensitivityMs > 8.0) {
             adaptiveVisualQualitySensitivityMs = clamp(adaptiveVisualQualitySensitivityMs, 0.25, 8.0);
             corrected = true;
         }
@@ -141,13 +154,19 @@ public class NozhConfig {
         }
 
         // improvementEpsilonAvgMs: 0.0-5.0
-        if (improvementEpsilonAvgMs < 0.0 || improvementEpsilonAvgMs > 5.0) {
+        if (!isFinite(improvementEpsilonAvgMs)) {
+            improvementEpsilonAvgMs = 0.5;
+            corrected = true;
+        } else if (improvementEpsilonAvgMs < 0.0 || improvementEpsilonAvgMs > 5.0) {
             improvementEpsilonAvgMs = clamp(improvementEpsilonAvgMs, 0.0, 5.0);
             corrected = true;
         }
 
         // improvementEpsilonP95Ms: 0.0-5.0
-        if (improvementEpsilonP95Ms < 0.0 || improvementEpsilonP95Ms > 5.0) {
+        if (!isFinite(improvementEpsilonP95Ms)) {
+            improvementEpsilonP95Ms = 1.0;
+            corrected = true;
+        } else if (improvementEpsilonP95Ms < 0.0 || improvementEpsilonP95Ms > 5.0) {
             improvementEpsilonP95Ms = clamp(improvementEpsilonP95Ms, 0.0, 5.0);
             corrected = true;
         }
@@ -168,9 +187,13 @@ public class NozhConfig {
         if (observationWindowSeconds < 3 || observationWindowSeconds > 10) {
             observationWindowSeconds = clamp(observationWindowSeconds, 3, 10);
             corrected = true;
+            addCriticalCorrection("observationWindowSeconds clamped to " + observationWindowSeconds + " (3-10)");
         }
 
-        if (hybridModelBlockConfidence < 0.0 || hybridModelBlockConfidence > 1.0) {
+        if (!isFinite(hybridModelBlockConfidence)) {
+            hybridModelBlockConfidence = 0.65;
+            corrected = true;
+        } else if (hybridModelBlockConfidence < 0.0 || hybridModelBlockConfidence > 1.0) {
             hybridModelBlockConfidence = clamp(hybridModelBlockConfidence, 0.0, 1.0);
             corrected = true;
         }
@@ -196,12 +219,15 @@ public class NozhConfig {
         if (cooldownActionMillis < 30000 || cooldownActionMillis > 600000) {
             cooldownActionMillis = clamp(cooldownActionMillis, 30000, 600000);
             corrected = true;
+            addCriticalCorrection("cooldownActionMillis clamped to " + cooldownActionMillis + " (30000-600000)");
         }
 
         // cooldownGlobalMinIntervalMillis: 10000-300000
         if (cooldownGlobalMinIntervalMillis < 10000 || cooldownGlobalMinIntervalMillis > 300000) {
             cooldownGlobalMinIntervalMillis = clamp(cooldownGlobalMinIntervalMillis, 10000, 300000);
             corrected = true;
+            addCriticalCorrection("cooldownGlobalMinIntervalMillis clamped to "
+                    + cooldownGlobalMinIntervalMillis + " (10000-300000)");
         }
 
         // maxChangesPerSession: 0-10
@@ -235,6 +261,11 @@ public class NozhConfig {
         int clampedHudOffsetY = clamp(hudOffsetY, -200, 200);
         if (clampedHudOffsetY != hudOffsetY) {
             hudOffsetY = clampedHudOffsetY;
+            corrected = true;
+        }
+
+        if (!isFinite(hudScale)) {
+            hudScale = 1.0;
             corrected = true;
         }
 
@@ -283,5 +314,25 @@ public class NozhConfig {
         return mode.equals("COMPACT")
                 || mode.equals("ANALYST")
                 || mode.equals("EXPERT");
+    }
+
+    private boolean isFinite(double value) {
+        return !Double.isNaN(value) && !Double.isInfinite(value);
+    }
+
+    private void addCriticalCorrection(String message) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        criticalCorrections.add(message);
+    }
+
+    public java.util.List<String> consumeCriticalCorrections() {
+        if (criticalCorrections.isEmpty()) {
+            return java.util.List.of();
+        }
+        java.util.List<String> snapshot = new java.util.ArrayList<>(criticalCorrections);
+        criticalCorrections.clear();
+        return snapshot;
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure config defaults and ranges reflect realistic hardware/monitor targets (FPS, cooldowns, `observationWindowSeconds`) to avoid unsafe behavior at runtime.
- Make intent of each configuration field explicit for maintainability and operator clarity by adding inline comments for what each field impacts.
- Harden `validate()` so it defensively fixes bad values (including NaN/Infinity) rather than throwing and collect any critical corrections for visibility.
- Provide a clear, single-line log of any critical auto-corrections during load so users and operators can diagnose why defaults were adjusted.

### Description
- Added per-field intent comments and adjusted default semantics in `NozhConfig` and enforced sane defaults such as ensuring `language` and `hudScale` are finite and canonicalized via `validate()`.
- Added defensive checks (`isFinite(...)` and additional clamp checks) and recordable critical corrections via a transient `criticalCorrections` list with `addCriticalCorrection(...)` and `consumeCriticalCorrections()`.
- Updated `ConfigManager.load()` to call `config.consumeCriticalCorrections()` after `validate()` and emit a concise `CRITICAL config corrections applied:` warning when present, and still re-save migrated/ corrected configs atomically.
- Documented recommended configuration defaults in `README.md` (English and Spanish) including `targetFps`, `observationWindowSeconds`, `cooldownActionMillis`, and `cooldownGlobalMinIntervalMillis`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e874ff828832d9a169cbd9696a4ee)